### PR TITLE
Generate analytics event type

### DIFF
--- a/Sources/Application.swift
+++ b/Sources/Application.swift
@@ -34,7 +34,7 @@ struct EventPanel: AsyncParsableCommand {
 
     func validate() throws {
         ConsoleLogger.isVerbose = verbose
-        
+
         try ConfigFileLocationProvider.initialize(
             configPath: config,
             workDir: workdir

--- a/Sources/CommandDefinitions/Add.swift
+++ b/Sources/CommandDefinitions/Add.swift
@@ -6,20 +6,20 @@ struct Add: AsyncParsableCommand {
         abstract: "Add event to EventPanel.yaml",
         discussion: """
         Adds a new event to your EventPanel.yaml configuration file.
-        
+
         USAGE:
             eventpanel add <event-id> [<version>]
-        
+
         ARGUMENTS:
             <event-id>    The unique identifier of the event to add
             <version>     (Optional) Specific version of the event to add
-        
+
         EXAMPLES:
             eventpanel add DWnQMGoYrvUyaTGpbmvr9
             eventpanel add DWnQMGoYrvUyaTGpbmvr9 --version 2
         """
     )
-    
+
     @Argument(help: "Event id")
     var eventId: String
 
@@ -38,4 +38,4 @@ struct Add: AsyncParsableCommand {
             try await DependencyContainer.shared.pullCommand.execute()
         }
     }
-} 
+}

--- a/Sources/CommandDefinitions/Add.swift
+++ b/Sources/CommandDefinitions/Add.swift
@@ -16,18 +16,21 @@ struct Add: AsyncParsableCommand {
         
         EXAMPLES:
             eventpanel add DWnQMGoYrvUyaTGpbmvr9
+            eventpanel add DWnQMGoYrvUyaTGpbmvr9 --version 2
         """
     )
     
     @Argument(help: "Event id")
     var eventId: String
 
-    @Argument(help: "Event version")
+    @Option(
+        name: [.customShort("v"), .long],
+        help: "Specific version of the event to add."
+    )
     var version: Int?
 
     @Flag(name: [.customLong("scheme-update")], help: "Apply scheme update during generation.")
     var schemeUpdate: Bool = true
-
 
     func run() async throws {
         try await DependencyContainer.shared.addCommand.execute(eventId: eventId, version: version)

--- a/Sources/CommandDefinitions/Auth.swift
+++ b/Sources/CommandDefinitions/Auth.swift
@@ -6,17 +6,17 @@ struct SetToken: AsyncParsableCommand {
         abstract: "Set API token",
         discussion: """
         Stores your EventPanel API token for authentication.
-        
+
         USAGE:
             eventpanel auth set-token <token>
-        
+
         ARGUMENTS:
             <token>    Your EventPanel API token
-        
+
         The token will be securely stored and used for all authenticated requests.
         """
     )
-    
+
     @Argument(help: "API token to store")
     var token: String
 
@@ -31,10 +31,10 @@ struct RemoveToken: AsyncParsableCommand {
         abstract: "Remove stored API token",
         discussion: """
         Removes your stored EventPanel API token.
-        
+
         USAGE:
             eventpanel auth remove-token
-        
+
         This will remove the stored API token and require re-authentication for future commands.
         """
     )
@@ -42,4 +42,4 @@ struct RemoveToken: AsyncParsableCommand {
     func run() async throws {
         try await DependencyContainer.shared.authCommand.removeToken()
     }
-} 
+}

--- a/Sources/CommandDefinitions/Deintegrate.swift
+++ b/Sources/CommandDefinitions/Deintegrate.swift
@@ -7,10 +7,10 @@ struct Deintegrate: AsyncParsableCommand {
         discussion: """
         Removes EventPanel integration from your project by cleaning up all configuration files
         and generated code.
-        
+
         USAGE:
             eventpanel deintegrate
-        
+
         This command will:
         - Remove EventPanel.yaml configuration
         - Clean up generated event files
@@ -21,4 +21,4 @@ struct Deintegrate: AsyncParsableCommand {
     func run() async throws {
         try await DependencyContainer.shared.deintegrateCommand.execute()
     }
-} 
+}

--- a/Sources/CommandDefinitions/Generate.swift
+++ b/Sources/CommandDefinitions/Generate.swift
@@ -6,13 +6,13 @@ struct Generate: AsyncParsableCommand {
         abstract: "Generate events according to versions from a EventPanel.yaml",
         discussion: """
         Generates event code based on the versions specified in your EventPanel.yaml file.
-        
+
         USAGE:
             eventpanel generate [--scheme-update]
-        
+
         OPTIONS:
             --scheme-update    Updates the scheme before generating events
-        
+
         This command will:
         - Read your EventPanel.yaml configuration
         - Generate event code for all configured events
@@ -23,11 +23,10 @@ struct Generate: AsyncParsableCommand {
     @Flag(name: [.customLong("scheme-update")], help: "Apply scheme update during generation.")
     var schemeUpdate: Bool = false
 
-
     func run() async throws {
         if schemeUpdate {
             try await DependencyContainer.shared.pullCommand.execute()
         }
         try await DependencyContainer.shared.generateCommand.execute()
     }
-} 
+}

--- a/Sources/CommandDefinitions/Help.swift
+++ b/Sources/CommandDefinitions/Help.swift
@@ -9,4 +9,4 @@ struct Help: AsyncParsableCommand {
     func run() async throws {
         ConsoleLogger.message(EventPanel.helpMessage())
     }
-} 
+}

--- a/Sources/CommandDefinitions/Init.swift
+++ b/Sources/CommandDefinitions/Init.swift
@@ -12,4 +12,4 @@ struct Init: AsyncParsableCommand {
     func run() async throws {
         try await DependencyContainer.shared.initCommand.execute(outputPath: output)
     }
-} 
+}

--- a/Sources/CommandDefinitions/List.swift
+++ b/Sources/CommandDefinitions/List.swift
@@ -6,13 +6,13 @@ struct List: AsyncParsableCommand {
         abstract: "List events",
         discussion: """
         Lists all events configured in your EventPanel.yaml file.
-        
+
         USAGE:
             eventpanel list [--page-size <number>]
-        
+
         OPTIONS:
             --page-size <number>    Number of items to display per page (default: 20)
-        
+
         The list shows:
         - Event ID
         - Current version
@@ -25,4 +25,4 @@ struct List: AsyncParsableCommand {
     func run() async throws {
         try await DependencyContainer.shared.listCommand.execute(pageSize: pageSize)
     }
-} 
+}

--- a/Sources/CommandDefinitions/Outdated.swift
+++ b/Sources/CommandDefinitions/Outdated.swift
@@ -6,10 +6,10 @@ struct Outdated: AsyncParsableCommand {
         abstract: "Show outdated events",
         discussion: """
         Checks for outdated events by comparing local versions with the latest available versions.
-        
+
         USAGE:
             eventpanel outdated
-        
+
         Display a list of events that have updates available
         """
     )
@@ -17,4 +17,4 @@ struct Outdated: AsyncParsableCommand {
     func run() async throws {
         try await DependencyContainer.shared.outdatedCommand.execute()
     }
-} 
+}

--- a/Sources/CommandDefinitions/Pull.swift
+++ b/Sources/CommandDefinitions/Pull.swift
@@ -6,10 +6,10 @@ struct Pull: AsyncParsableCommand {
         abstract: "Fetch and store the latest scheme from the server",
         discussion: """
         Fetches the latest event scheme from the server and updates your local configuration.
-        
+
         USAGE:
             eventpanel pull
-        
+
         This command will:
         - Connect to the EventPanel server
         - Download the latest event scheme
@@ -19,4 +19,4 @@ struct Pull: AsyncParsableCommand {
     func run() async throws {
         try await DependencyContainer.shared.pullCommand.execute()
     }
-} 
+}

--- a/Sources/CommandDefinitions/Update.swift
+++ b/Sources/CommandDefinitions/Update.swift
@@ -7,20 +7,20 @@ struct Update: AsyncParsableCommand {
         discussion: """
         Updates the events identified by event id, which is a space-delimited list of event IDs.
         If no events are specified, it updates all outdated events.
-        
+
         USAGE:
             eventpanel update [<event-id>...]
-        
+
         ARGUMENTS:
             <event-id>...    Space-delimited list of event IDs to update. If not provided, updates all outdated events.
-        
+
         EXAMPLES:
             eventpanel update
-            
+
             eventpanel update DWnQMGoYrvUyaTGpbmvr9
-            
+
             eventpanel update DWnQMGoYrvUyaTGpbmvr9 cKMpDL-DtggQFHxOoKLnq
-        
+
         This command will:
         - Check for available updates for the specified events
         - Update the events to their latest versions
@@ -40,4 +40,4 @@ struct Update: AsyncParsableCommand {
             try await DependencyContainer.shared.pullCommand.execute()
         }
     }
-} 
+}

--- a/Sources/Commands/AddCommand.swift
+++ b/Sources/Commands/AddCommand.swift
@@ -29,7 +29,7 @@ final class AddCommand {
         self.apiService = apiService
         self.configProvider = configProvider
     }
-    
+
     func execute(eventId: String, version: Int?) async throws {
         let eventPanelYaml = try await configProvider.getEventPanelYaml()
         let eventVersion = try await validateEvent(
@@ -43,9 +43,9 @@ final class AddCommand {
 
         ConsoleLogger.success("Added event '\(eventId)'")
     }
-    
+
     // MARK: - Private Methods
-    
+
     /// Validates the event name with the server
     private func validateEvent(eventId: String, version: Int?, source: Source) async throws -> Int {
         if let version, version < 0 {
@@ -72,7 +72,7 @@ final class AddCommand {
             throw AddCommandError.eventValidationFailed(error.localizedDescription)
         }
     }
-    
+
     /// Adds the validated event to the YAML configuration
     private func addEventToYaml(eventId: String, eventVersion: Int, eventPanelYaml: EventPanelYaml) async throws {
         try await eventPanelYaml.addEvent(eventId: eventId, eventVersion: eventVersion)
@@ -84,4 +84,4 @@ final class AddCommand {
 private struct EventValidationResponse: Decodable {
     let isValid: Bool
     let message: String?
-} 
+}

--- a/Sources/Commands/AuthCommand.swift
+++ b/Sources/Commands/AuthCommand.swift
@@ -15,14 +15,14 @@ final class AuthCommand {
         self.authTokenService = authTokenService
         self.configProvider = configProvider
     }
-    
+
     func setToken(_ token: String) async throws {
         let id = try await fetchWorkspaceId(token: token)
 
         try await authTokenService.setToken(token, workspaceId: id)
         ConsoleLogger.success("API token has been saved successfully")
     }
-    
+
     func removeToken() async throws {
         let eventPanelYaml = try await configProvider.getEventPanelYaml()
         let workspaceId = await eventPanelYaml.getWorkspaceId()

--- a/Sources/Commands/DeintegrateCommand.swift
+++ b/Sources/Commands/DeintegrateCommand.swift
@@ -3,7 +3,7 @@ import Foundation
 final class DeintegrateCommand {
     private let configFileLocation: ConfigFileLocation
     private let fileManager: FileManager
-    
+
     init(
         configFileLocation: ConfigFileLocation,
         fileManager: FileManager
@@ -11,7 +11,7 @@ final class DeintegrateCommand {
         self.configFileLocation = configFileLocation
         self.fileManager = fileManager
     }
-    
+
     func execute() async throws {
         try removeConfigFile()
         try removeCacheFolder()

--- a/Sources/Commands/InitCommand/InitCommand.swift
+++ b/Sources/Commands/InitCommand/InitCommand.swift
@@ -17,7 +17,7 @@ final class InitCommand {
         self.configFileLocation = configFileLocation
         self.outputPathValidator = outputPathValidator
     }
-    
+
     func execute(outputPath: String) async throws {
         let eventPanelYaml = try? await configProvider.getEventPanelYaml()
         if eventPanelYaml != nil { throw InitCommandError.fileAlreadyExists }
@@ -53,7 +53,6 @@ final class InitCommand {
             return .kotlingen(.make(outputFilePath: outputFilePath))
         }
     }
-    
 
     private func detectProject(in directory: URL) throws -> ProjectDirectory {
         guard let project = projectDetector.detectProject(in: directory) else {

--- a/Sources/Commands/ListCommand.swift
+++ b/Sources/Commands/ListCommand.swift
@@ -3,7 +3,7 @@ import Get
 
 enum ListCommandError: LocalizedError {
     case invalidPageSize(String)
-    
+
     var errorDescription: String? {
         switch self {
         case .invalidPageSize(let size):
@@ -15,51 +15,51 @@ enum ListCommandError: LocalizedError {
 final class ListCommand {
     private let networkClient: NetworkClient
     private let configProvider: ConfigProvider
-    
+
     init(networkClient: NetworkClient, configProvider: ConfigProvider) {
         self.networkClient = networkClient
         self.configProvider = configProvider
     }
-    
+
     func execute(pageSize: Int) async throws {
         let eventPanelYaml = try await configProvider.getEventPanelYaml()
         let events = await eventPanelYaml.getEvents()
-        
+
         // Display events with pagination
         displayEvents(events, pageSize: pageSize)
     }
-    
+
     private func displayEvents(_ events: [Event], pageSize: Int) {
         if events.isEmpty {
             ConsoleLogger.message("No events found")
             return
         }
-        
+
         let totalPages = (events.count + pageSize - 1) / pageSize
         var currentPage = 1
-        
+
         while true {
             let startIndex = (currentPage - 1) * pageSize
             let endIndex = min(startIndex + pageSize, events.count)
             let pageEvents = events[startIndex..<endIndex]
-            
+
             // Print header
             ConsoleLogger.message("\nEvents (Page \(currentPage)/\(totalPages)):")
             ConsoleLogger.message("Event ID".padding(toLength: 40, withPad: " ", startingAt: 0) + "Version")
             ConsoleLogger.message(String(repeating: "-", count: 50))
-            
+
             // Print events
             for event in pageEvents {
                 let eventStr = event.id.padding(toLength: 40, withPad: " ", startingAt: 0)
                 let versionStr = String(event.version ?? 1)
                 ConsoleLogger.message("\(eventStr)\(versionStr)")
             }
-            
+
             // Handle pagination
             if currentPage == totalPages {
                 break
             }
-            
+
             ConsoleLogger.message("\nPress 'n' for next page, 'p' for previous page, or 'q' to quit")
             if let input = readLine()?.lowercased() {
                 switch input {
@@ -75,4 +75,4 @@ final class ListCommand {
             }
         }
     }
-} 
+}

--- a/Sources/Commands/OutdatedCommand.swift
+++ b/Sources/Commands/OutdatedCommand.swift
@@ -3,7 +3,7 @@ import Get
 
 enum OutdatedCommandError: LocalizedError {
     case eventCheckFailed(String)
-    
+
     var errorDescription: String? {
         switch self {
         case .eventCheckFailed(let message):
@@ -18,7 +18,7 @@ private struct OutdatedEvent {
     let eventId: String
     let currentVersion: Int
     let latestVersion: Int
-    
+
     var displayString: String {
         "- \(eventId) \(currentVersion) -> latest version \(latestVersion)"
     }
@@ -32,22 +32,22 @@ final class OutdatedCommand {
         self.apiService = apiService
         self.configProvider = configProvider
     }
-    
+
     func execute() async throws {
         ConsoleLogger.message("Checking for outdated events...")
 
         let eventPanelYaml = try await configProvider.getEventPanelYaml()
         let events = await eventPanelYaml.getEvents()
-        
+
         let outdatedEvents = try await checkEventsForUpdates(
             events,
             source: eventPanelYaml.getSource()
         )
         displayResults(outdatedEvents)
     }
-    
+
     // MARK: - Private Methods
-    
+
     private func checkEventsForUpdates(_ events: [Event], source: Source) async throws -> [OutdatedEvent] {
         do {
             let requestEvents = events.map { event in
@@ -82,13 +82,13 @@ final class OutdatedCommand {
             throw OutdatedCommandError.eventCheckFailed(error.localizedDescription)
         }
     }
-    
+
     private func displayResults(_ outdatedEvents: [OutdatedEvent]) {
         if outdatedEvents.isEmpty {
             ConsoleLogger.message("All events are up to date")
             return
         }
-        
+
         ConsoleLogger.message("\nThe following event updates are available:")
         for event in outdatedEvents {
             ConsoleLogger.message(event.displayString)

--- a/Sources/Commands/PullCommand.swift
+++ b/Sources/Commands/PullCommand.swift
@@ -6,7 +6,7 @@ enum PullCommandError: LocalizedError {
     case invalidResponse
     case saveFailed(String)
     case eventsAreMissing
-    
+
     var errorDescription: String? {
         switch self {
         case .fetchFailed(let message):
@@ -26,7 +26,7 @@ final class PullCommand {
     private let configProvider: ConfigProvider
     private let configFileLocation: ConfigFileLocation
     private let fileManager: FileManager
-    
+
     init(
         apiService: EventPanelAPIService,
         configProvider: ConfigProvider,
@@ -38,7 +38,7 @@ final class PullCommand {
         self.configFileLocation = configFileLocation
         self.fileManager = fileManager
     }
-    
+
     func execute() async throws {
         ConsoleLogger.message("Fetching latest scheme...")
 
@@ -57,12 +57,12 @@ final class PullCommand {
 
         // Save scheme to disk
         try saveScheme(scheme)
-        
+
         ConsoleLogger.success("Successfully pulled and stored scheme")
     }
-    
+
     // MARK: - Private Methods
-    
+
     private func fetchScheme(
         events: [Event],
         source: Source
@@ -81,15 +81,15 @@ final class PullCommand {
             throw PullCommandError.fetchFailed(error.localizedDescription)
         }
     }
-    
+
     private func saveScheme(_ scheme: WorkspaceScheme) throws {
         let encoder = JSONEncoder()
         encoder.keyEncodingStrategy = .convertToSnakeCase
         encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
-        
+
         do {
             let data = try encoder.encode(scheme)
-            
+
             // Create .eventpanel directory if it doesn't exist
             let eventPanelDir = configFileLocation.cacheDirectory
             try fileManager.createDirectory(
@@ -97,7 +97,7 @@ final class PullCommand {
                 withIntermediateDirectories: true,
                 attributes: nil
             )
-            
+
             // Save scheme.json
             let schemeURL = eventPanelDir.appendingPathComponent("scheme.json")
             try data.write(to: schemeURL)

--- a/Sources/Commands/UpdateCommand.swift
+++ b/Sources/Commands/UpdateCommand.swift
@@ -29,7 +29,7 @@ final class UpdateCommand {
         self.apiService = apiService
         self.configProvider = configProvider
     }
-    
+
     func execute(eventIds: [String]) async throws {
         let eventPanelYaml = try await configProvider.getEventPanelYaml()
         if eventIds.count == 1, let eventId = eventIds.first {
@@ -48,21 +48,21 @@ final class UpdateCommand {
             )
         }
     }
-    
+
     // MARK: - Private Methods
 
     private func updateSingleEvent(eventId: String, source: Source, eventPanelYaml: EventPanelYaml) async throws {
         ConsoleLogger.message("Checking for updates to event '\(eventId)'...")
 
         let events = await eventPanelYaml.getEvents()
-        
+
         // Verify event exists in configuration
         guard let event = events.first(where: { $0.id == eventId }) else {
             throw UpdateCommandError.eventNotFound(eventId)
         }
-        
+
         let currentVersion = event.version ?? 1
-        
+
         do {
             let updatedEvent = try await apiService.getLatestEvent(
                 eventId: eventId,
@@ -85,7 +85,7 @@ final class UpdateCommand {
             throw UpdateCommandError.eventCheckFailed(error.localizedDescription)
         }
     }
-    
+
     private func updateAllEvents(eventPanelYaml: EventPanelYaml) async throws {
         try await updateEvents(eventIds: nil, source: eventPanelYaml.getSource(), eventPanelYaml: eventPanelYaml)
     }
@@ -133,7 +133,7 @@ final class UpdateCommand {
             if updatedEvents > 0 {
                 ConsoleLogger.success("All events are successfully up to date.")
             } else {
-                ConsoleLogger.success("Event synchronization complete. No changes detected");
+                ConsoleLogger.success("Event synchronization complete. No changes detected")
             }
         } catch let error as APIError {
             throw UpdateCommandError.eventCheckFailed(error.localizedDescription)
@@ -142,7 +142,7 @@ final class UpdateCommand {
         }
     }
 
-    private func validateEventsAreExist(events:  [Event], updateEventIds: Set<String>) throws {
+    private func validateEventsAreExist(events: [Event], updateEventIds: Set<String>) throws {
         let yamlFileEventIds = Set(events.map(\.id))
         let notExistedEvents = updateEventIds.subtracting(yamlFileEventIds)
         if !notExistedEvents.isEmpty {

--- a/Sources/CommonCommandError.swift
+++ b/Sources/CommonCommandError.swift
@@ -9,4 +9,4 @@ enum CommandError: LocalizedError {
             return "No `EventPanel.yaml' found in the project directory"
         }
     }
-} 
+}

--- a/Sources/DependencyContainer.swift
+++ b/Sources/DependencyContainer.swift
@@ -34,7 +34,7 @@ final class DependencyContainer: @unchecked Sendable {
             configProvider: configProvider
         )
     }()
-    
+
     private lazy var networkClient: NetworkClient = {
         let authAPIClientDelegate = AuthAPIClientDelegate(authTokenProvider: authTokenProvider)
         let networkClient = NetworkClient(baseURL: Environment.current.baseURL) {
@@ -42,7 +42,7 @@ final class DependencyContainer: @unchecked Sendable {
         }
         return networkClient
     }()
-    
+
     private lazy var apiService: EventPanelAPIService = {
         return EventPanelAPIService(networkClient: networkClient)
     }()
@@ -62,27 +62,27 @@ final class DependencyContainer: @unchecked Sendable {
     private(set) lazy var addCommand: AddCommand = {
         return AddCommand(apiService: apiService, configProvider: configProvider)
     }()
-    
+
     private(set) lazy var deintegrateCommand: DeintegrateCommand = {
         return DeintegrateCommand(
             configFileLocation: configFileLocation,
             fileManager: fileManager
         )
     }()
-    
+
     private(set) lazy var generateCommand: GenerateCommand = {
         return GenerateCommand(
             configProvider: configProvider,
             generatorPluginFactory: generatorPluginFactory
         )
     }()
-    
+
     private(set) lazy var outputPathValidator: OutputPathValidator = {
         return DefaultOutputPathValidator(
             fileManager: fileManager
         )
     }()
-    
+
     private(set) lazy var initCommand: InitCommand = {
         return InitCommand(
             projectDetector: CompositeProjectDetector(projectDetectors: [
@@ -94,15 +94,15 @@ final class DependencyContainer: @unchecked Sendable {
             outputPathValidator: outputPathValidator
         )
     }()
-    
+
     private(set) lazy var listCommand: ListCommand = {
         return ListCommand(networkClient: networkClient, configProvider: configProvider)
     }()
-    
+
     private(set) lazy var outdatedCommand: OutdatedCommand = {
         return OutdatedCommand(apiService: apiService, configProvider: configProvider)
     }()
-    
+
     private(set) lazy var pullCommand: PullCommand = {
         return PullCommand(
             apiService: apiService,
@@ -111,11 +111,11 @@ final class DependencyContainer: @unchecked Sendable {
             fileManager: fileManager
         )
     }()
-    
+
     private(set) lazy var updateCommand: UpdateCommand = {
         return UpdateCommand(apiService: apiService, configProvider: configProvider)
     }()
-    
+
     // MARK: - Private Initializer
     private init() {}
-} 
+}

--- a/Sources/Models/ConfigFileLocation.swift
+++ b/Sources/Models/ConfigFileLocation.swift
@@ -10,9 +10,7 @@ struct ConfigFileLocation {
         configDirectory.appendingPathComponent(".eventpanel")
     }
 
-    static var configName: String {
-        "EventPanel.yaml"
-    }
+    static var configName: String { "EventPanel.yaml" }
 
     init(
         configPath: String? = nil,
@@ -27,7 +25,7 @@ struct ConfigFileLocation {
 }
 
 actor ConfigFileLocationProvider {
-    static private var _configFileLocation: ConfigFileLocation?
+    static nonisolated(unsafe) private var _configFileLocation: ConfigFileLocation?
     
     static var configFileLocation: ConfigFileLocation {
         guard let location = _configFileLocation else {

--- a/Sources/Models/ConfigFileLocation.swift
+++ b/Sources/Models/ConfigFileLocation.swift
@@ -26,14 +26,14 @@ struct ConfigFileLocation {
 
 actor ConfigFileLocationProvider {
     static nonisolated(unsafe) private var _configFileLocation: ConfigFileLocation?
-    
+
     static var configFileLocation: ConfigFileLocation {
         guard let location = _configFileLocation else {
             fatalError("ConfigFileLocationProvider not initialized. Call initialize() first.")
         }
         return location
     }
-    
+
     static func initialize(
         configPath: String?,
         workDir: String?,

--- a/Sources/Models/EventPanelYaml.swift
+++ b/Sources/Models/EventPanelYaml.swift
@@ -6,7 +6,7 @@ enum EventPanelYamlError: LocalizedError {
     case eventAlreadyExists(eventId: String)
     case eventNotFound(eventId: String)
     case missingRequiredField(String)
-    
+
     var errorDescription: String? {
         switch self {
         case .invalidYamlStructure(let message):
@@ -29,7 +29,7 @@ actor EventPanelYaml {
         self.path = path
         let yamlString = try String(contentsOfFile: path, encoding: .utf8)
         let decoder = YAMLDecoder()
-        
+
         do {
             self.config = try decoder.decode(EventPanelConfig.self, from: yamlString)
         } catch let error as DecodingError {
@@ -45,24 +45,24 @@ actor EventPanelYaml {
             }
         }
     }
-    
+
     static func createDefault(at path: String, projectInfo: ProjectInfo) throws {
         let config = EventPanelConfig(
             source: projectInfo.source,
             plugin: projectInfo.plugin,
             events: []
         )
-        
+
         let encoder = YAMLEncoder()
         let yamlString = try encoder.encode(config)
-        
+
         // Add header comment
         let finalYaml = """
         # EventPanel configuration file
-        
+
         \(yamlString)
         """
-        
+
         try finalYaml.write(toFile: path, atomically: true, encoding: .utf8)
     }
 
@@ -87,12 +87,12 @@ actor EventPanelYaml {
     func getEvents() -> [Event] {
         config.events
     }
-    
+
     func updateEvent(eventId: String, version: Int) throws {
         guard let eventIndex = config.events.firstIndex(where: { $0.id == eventId }) else {
             throw EventPanelYamlError.eventNotFound(eventId: eventId)
         }
-        
+
         config.events[eventIndex].version = version
         try save()
     }

--- a/Sources/Models/YamlModels.swift
+++ b/Sources/Models/YamlModels.swift
@@ -12,7 +12,7 @@ struct EventPanelConfig: Codable {
         case plugin
         case events
     }
-    
+
     init(source: Source, plugin: Plugin, events: [Event] = []) {
         self.source = source
         self.plugin = plugin

--- a/Sources/Plugins/KotlinGen/KotlinFileNameValidator.swift
+++ b/Sources/Plugins/KotlinGen/KotlinFileNameValidator.swift
@@ -6,44 +6,44 @@ struct KotlinFileNameValidator {
         guard !fileName.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
             throw KotlinFileNameValidationError.emptyFileName
         }
-        
+
         let trimmedFileName = fileName.trimmingCharacters(in: .whitespacesAndNewlines)
-        
+
         // Check if filename has .kt extension
         guard trimmedFileName.hasSuffix(".kt") else {
             throw KotlinFileNameValidationError.missingKotlinExtension
         }
-        
+
         // Remove .kt extension to validate the base name
         let baseName = String(trimmedFileName.dropLast(3)) // Remove ".kt"
-        
+
         // Check if base name is empty after removing extension
         guard !baseName.isEmpty else {
             throw KotlinFileNameValidationError.emptyBaseName
         }
-        
+
         // Check if base name starts with a valid Kotlin identifier character
         guard isValidKotlinIdentifierStart(baseName.first) else {
             throw KotlinFileNameValidationError.invalidStartCharacter
         }
-        
+
         // Check if all characters in base name are valid file name characters
         guard baseName.allSatisfy({ isValidFileNameCharacter($0) }) else {
             throw KotlinFileNameValidationError.invalidCharacters
         }
     }
-    
+
     private static func isValidKotlinIdentifierStart(_ character: Character?) -> Bool {
         guard let char = character else { return false }
-        
+
         // Valid start characters: letters, underscore, dollar sign
         return char.isLetter || char == "_" || char == "$"
     }
-    
+
     private static func isValidFileNameCharacter(_ character: Character) -> Bool {
         // Only forbid truly problematic macOS characters: : / \ ? * " < > |
         let forbiddenCharacters: Set<Character> = [":", "/", "\\", "?", "*", "\"", "<", ">", "|"]
-        
+
         return !forbiddenCharacters.contains(character)
     }
 }
@@ -54,7 +54,7 @@ enum KotlinFileNameValidationError: LocalizedError {
     case emptyBaseName
     case invalidStartCharacter
     case invalidCharacters
-    
+
     var errorDescription: String? {
         switch self {
         case .emptyFileName:

--- a/Sources/Plugins/KotlinGen/KotlinGen.swift
+++ b/Sources/Plugins/KotlinGen/KotlinGen.swift
@@ -5,7 +5,7 @@ import StencilEventPanelKit
 enum KotlinGenError: LocalizedError {
     case generateFailed(String)
     case saveFailed(String)
-    
+
     var errorDescription: String? {
         switch self {
         case .generateFailed(let message):
@@ -40,7 +40,7 @@ actor KotlinGen: CodeGeneratorPlugin {
         let scheme = try schemeManagerLoader.read()
         let kotlinGenScheme = try KotlinGenWorkspaceScheme(from: scheme)
         let stencilTemplate = try KotlinGenStencilTemplate.default()
-        
+
         let rendered = try generator.generate(scheme: kotlinGenScheme, stencilTemplate: stencilTemplate)
         try saveGeneratedCode(rendered: rendered)
     }

--- a/Sources/Plugins/KotlinGen/KotlinGenEmbeddedTemplate.swift
+++ b/Sources/Plugins/KotlinGen/KotlinGenEmbeddedTemplate.swift
@@ -149,6 +149,13 @@ package {{param.packageName}}
 {% call customTypesBlock file.document %}
 {% endif %}
 {% endfor %}
+{% if param.shouldGenerateType %}
+
+{{accessModifier}} data class {{eventClassName}}(
+  {{accessModifier}} val name: String,
+  {{accessModifier}} val parameters: Map<String, Any> = emptyMap()
+)
+{% endif %}
 {% else %}
 // No files found
 {% endif %}

--- a/Sources/Plugins/KotlinGen/KotlinGenGenerator.swift
+++ b/Sources/Plugins/KotlinGen/KotlinGenGenerator.swift
@@ -2,11 +2,11 @@ import StencilEventPanelKit
 
 struct KotlinGenGenerator {
     private let config: KotlinGenPlugin
-    
+
     init(config: KotlinGenPlugin) {
         self.config = config
     }
-    
+
     func generate(scheme: KotlinGenWorkspaceScheme, stencilTemplate: KotlinGenStencilTemplate) throws -> String {
         let environment = stencilSwiftEnvironment(
             templates: [stencilTemplate.name: stencilTemplate.template]
@@ -38,4 +38,4 @@ struct KotlinGenGenerator {
             throw KotlinGenError.generateFailed(error.localizedDescription)
         }
     }
-} 
+}

--- a/Sources/Plugins/KotlinGen/KotlinGenGenerator.swift
+++ b/Sources/Plugins/KotlinGen/KotlinGenGenerator.swift
@@ -20,7 +20,8 @@ struct KotlinGenGenerator {
             KotlinGenParams(
                 packageName: config.packageName,
                 eventClassName: config.eventClassName,
-                documentation: config.documentation
+                documentation: config.documentation,
+                shouldGenerateType: config.shouldGenerateType
             ),
             keyEncodingStrategy: .useDefaultKeys
         )!

--- a/Sources/Plugins/KotlinGen/KotlinGenParams.swift
+++ b/Sources/Plugins/KotlinGen/KotlinGenParams.swift
@@ -5,4 +5,4 @@ struct KotlinGenParams: Codable {
     let eventClassName: String
     let documentation: Bool
     let shouldGenerateType: Bool
-} 
+}

--- a/Sources/Plugins/KotlinGen/KotlinGenParams.swift
+++ b/Sources/Plugins/KotlinGen/KotlinGenParams.swift
@@ -4,4 +4,5 @@ struct KotlinGenParams: Codable {
     let packageName: String
     let eventClassName: String
     let documentation: Bool
+    let shouldGenerateType: Bool
 } 

--- a/Sources/Plugins/KotlinGen/KotlinGenPlugin.swift
+++ b/Sources/Plugins/KotlinGen/KotlinGenPlugin.swift
@@ -5,6 +5,7 @@ struct KotlinGenPlugin: Codable {
     let packageName: String
     let eventClassName: String
     let documentation: Bool
+    let shouldGenerateType: Bool
 }
 
 extension KotlinGenPlugin {
@@ -18,7 +19,8 @@ extension KotlinGenPlugin {
             outputFilePath: outputFilePath,
             packageName: "com.analytics.events",
             eventClassName: "AnalyticsEvent",
-            documentation: true
+            documentation: true,
+            shouldGenerateType: true
         )
     }
 } 

--- a/Sources/Plugins/KotlinGen/KotlinGenPlugin.swift
+++ b/Sources/Plugins/KotlinGen/KotlinGenPlugin.swift
@@ -11,7 +11,7 @@ struct KotlinGenPlugin: Codable {
 extension KotlinGenPlugin {
     static let `default`: KotlinGenPlugin = .make()
     static let defaultOutputFilePath = "GeneratedAnalyticsEvents.kt"
-    
+
     static func make(
         outputFilePath: String = defaultOutputFilePath
     ) -> KotlinGenPlugin {
@@ -23,4 +23,4 @@ extension KotlinGenPlugin {
             shouldGenerateType: true
         )
     }
-} 
+}

--- a/Sources/Plugins/KotlinGen/KotlinGenStencilTemplate.swift
+++ b/Sources/Plugins/KotlinGen/KotlinGenStencilTemplate.swift
@@ -12,4 +12,4 @@ extension KotlinGenStencilTemplate {
             template: KotlinGenEmbeddedTemplate.template
         )
     }
-} 
+}

--- a/Sources/Plugins/KotlinGen/kotlin.stencil
+++ b/Sources/Plugins/KotlinGen/kotlin.stencil
@@ -145,6 +145,13 @@ package {{param.packageName}}
 {% call customTypesBlock file.document %}
 {% endif %}
 {% endfor %}
+{% if param.shouldGenerateType %}
+
+{{accessModifier}} data class {{eventClassName}}(
+  {{accessModifier}} val name: String,
+  {{accessModifier}} val parameters: Map<String, Any> = emptyMap()
+)
+{% endif %}
 {% else %}
 // No files found
 {% endif %}

--- a/Sources/Plugins/Plugin.swift
+++ b/Sources/Plugins/Plugin.swift
@@ -42,4 +42,3 @@ enum Plugin: Codable {
         }
     }
 }
-

--- a/Sources/Plugins/Swiftgen/SwiftFileNameValidator.swift
+++ b/Sources/Plugins/Swiftgen/SwiftFileNameValidator.swift
@@ -6,44 +6,44 @@ struct SwiftFileNameValidator {
         guard !fileName.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
             throw SwiftFileNameValidationError.emptyFileName
         }
-        
+
         let trimmedFileName = fileName.trimmingCharacters(in: .whitespacesAndNewlines)
-        
+
         // Check if filename has .swift extension
         guard trimmedFileName.hasSuffix(".swift") else {
             throw SwiftFileNameValidationError.missingSwiftExtension
         }
-        
+
         // Remove .swift extension to validate the base name
         let baseName = String(trimmedFileName.dropLast(6)) // Remove ".swift"
-        
+
         // Check if base name is empty after removing extension
         guard !baseName.isEmpty else {
             throw SwiftFileNameValidationError.emptyBaseName
         }
-        
+
         // Check if base name starts with a valid Swift identifier character
         guard isValidSwiftIdentifierStart(baseName.first) else {
             throw SwiftFileNameValidationError.invalidStartCharacter
         }
-        
+
         // Check if all characters in base name are valid file name characters
         guard baseName.allSatisfy({ isValidFileNameCharacter($0) }) else {
             throw SwiftFileNameValidationError.invalidCharacters
         }
     }
-    
+
     private static func isValidSwiftIdentifierStart(_ character: Character?) -> Bool {
         guard let char = character else { return false }
-        
+
         // Valid start characters: letters, underscore
         return char.isLetter || char == "_"
     }
-    
+
     private static func isValidFileNameCharacter(_ character: Character) -> Bool {
         // Only forbid truly problematic macOS characters: : / \ ? * " < > |
         let forbiddenCharacters: Set<Character> = [":", "/", "\\", "?", "*", "\"", "<", ">", "|"]
-        
+
         return !forbiddenCharacters.contains(character)
     }
 }
@@ -54,7 +54,7 @@ enum SwiftFileNameValidationError: LocalizedError {
     case emptyBaseName
     case invalidStartCharacter
     case invalidCharacters
-    
+
     var errorDescription: String? {
         switch self {
         case .emptyFileName:

--- a/Sources/Plugins/Swiftgen/SwiftGen.swift
+++ b/Sources/Plugins/Swiftgen/SwiftGen.swift
@@ -5,7 +5,7 @@ import StencilEventPanelKit
 enum SwiftGenError: LocalizedError {
     case generateFailed(String)
     case saveFailed(String)
-    
+
     var errorDescription: String? {
         switch self {
         case .generateFailed(let message):
@@ -40,7 +40,7 @@ actor SwiftGen: CodeGeneratorPlugin {
         let scheme = try schemeManagerLoader.read()
         let swiftgenScheme = try SwiftGenWorkspaceScheme(from: scheme)
         let stencilTemplate = try SwiftGenStencilTemplate.default()
-        
+
         let rendered = try generator.generate(scheme: swiftgenScheme, stencilTemplate: stencilTemplate)
         try saveGeneratedCode(rendered: rendered)
     }

--- a/Sources/Plugins/Swiftgen/SwiftGenEmbeddedTemplate.swift
+++ b/Sources/Plugins/Swiftgen/SwiftGenEmbeddedTemplate.swift
@@ -161,8 +161,8 @@ private extension Dictionary where Value == Any? {
     }
   }
 }
-
 {% if param.shouldGenerateType %}
+
 {{accessModifier}} struct {{eventClassName}} {
   {{accessModifier}} let name: String
   {{accessModifier}} let parameters: [String: Any]

--- a/Sources/Plugins/Swiftgen/SwiftGenEmbeddedTemplate.swift
+++ b/Sources/Plugins/Swiftgen/SwiftGenEmbeddedTemplate.swift
@@ -152,18 +152,30 @@ extension {{param.enumName|default:"GeneratedAnalyticsEvents"}} {
 }
 {% endif %}
 {% endfor %}
+
+private extension Dictionary where Value == Any? {
+  /// Returns dictionary with filtered out `nil` and `NSNull` values
+  func byExcludingNilValues() -> [Key: Any] {
+    return compactMapValues { value -> Any? in
+      value is NSNull ? nil : value
+    }
+  }
+}
+
+{% if param.shouldGenerateType %}
+{{accessModifier}} struct {{eventClassName}} {
+  {{accessModifier}} let name: String
+  {{accessModifier}} let parameters: [String: Any]
+
+  {{accessModifier}} init(name: String, parameters: [String: Any] = [:]) {
+    self.name = name
+    self.parameters = parameters
+  }
+}
+{% endif %}
 {% else %}
 // No files found
 {% endif %}
-
-private extension Dictionary where Value == Any? {
-    /// Returns dictionary with filtered out `nil` and `NSNull` values
-    func byExcludingNilValues() -> [Key: Any] {
-        return compactMapValues { value -> Any? in
-            value is NSNull ? nil : value
-        }
-    }
-} 
 // swiftlint:enable all
 """
 }

--- a/Sources/Plugins/Swiftgen/SwiftGenGenerator.swift
+++ b/Sources/Plugins/Swiftgen/SwiftGenGenerator.swift
@@ -4,7 +4,7 @@ import StencilEventPanelKit
 
 enum SwiftGenGeneratorError: LocalizedError {
     case generateFailed(String)
-    
+
     var errorDescription: String? {
         switch self {
         case .generateFailed(let message):
@@ -15,11 +15,11 @@ enum SwiftGenGeneratorError: LocalizedError {
 
 struct SwiftGenGenerator {
     private let config: SwiftGenPlugin
-    
+
     init(config: SwiftGenPlugin) {
         self.config = config
     }
-    
+
     func generate(scheme: SwiftGenWorkspaceScheme, stencilTemplate: SwiftGenStencilTemplate) throws -> String {
         let environment = stencilSwiftEnvironment(
             templates: [stencilTemplate.name: stencilTemplate.template]
@@ -51,4 +51,4 @@ struct SwiftGenGenerator {
             throw SwiftGenGeneratorError.generateFailed(error.localizedDescription)
         }
     }
-} 
+}

--- a/Sources/Plugins/Swiftgen/SwiftGenGenerator.swift
+++ b/Sources/Plugins/Swiftgen/SwiftGenGenerator.swift
@@ -33,7 +33,8 @@ struct SwiftGenGenerator {
             SwiftGenParams(
                 enumName: config.namespace,
                 eventClassName: config.eventTypeName,
-                documentation: config.documentation
+                documentation: config.documentation,
+                shouldGenerateType: config.shouldGenerateType
             ),
             keyEncodingStrategy: .useDefaultKeys
         )!

--- a/Sources/Plugins/Swiftgen/SwiftGenParams.swift
+++ b/Sources/Plugins/Swiftgen/SwiftGenParams.swift
@@ -2,4 +2,5 @@ struct SwiftGenParams: Codable {
     let enumName: String
     let eventClassName: String
     let documentation: Bool
+    let shouldGenerateType: Bool
 }

--- a/Sources/Plugins/Swiftgen/SwiftGenPlugin.swift
+++ b/Sources/Plugins/Swiftgen/SwiftGenPlugin.swift
@@ -5,6 +5,7 @@ struct SwiftGenPlugin: Codable {
     let namespace: String
     let eventTypeName: String
     let documentation: Bool
+    let shouldGenerateType: Bool
 }
 
 extension SwiftGenPlugin {
@@ -18,7 +19,8 @@ extension SwiftGenPlugin {
             outputFilePath: outputFilePath,
             namespace: "AnalyticsEvents",
             eventTypeName: "AnalyticsEvent",
-            documentation: true
+            documentation: true,
+            shouldGenerateType: true
         )
     }
 }

--- a/Sources/Plugins/Swiftgen/swift5.stencil
+++ b/Sources/Plugins/Swiftgen/swift5.stencil
@@ -157,8 +157,8 @@ private extension Dictionary where Value == Any? {
     }
   }
 }
-
 {% if param.shouldGenerateType %}
+
 {{accessModifier}} struct {{eventClassName}} {
   {{accessModifier}} let name: String
   {{accessModifier}} let parameters: [String: Any]

--- a/Sources/Plugins/Swiftgen/swift5.stencil
+++ b/Sources/Plugins/Swiftgen/swift5.stencil
@@ -148,16 +148,28 @@ extension {{param.enumName|default:"GeneratedAnalyticsEvents"}} {
 }
 {% endif %}
 {% endfor %}
+
+private extension Dictionary where Value == Any? {
+  /// Returns dictionary with filtered out `nil` and `NSNull` values
+  func byExcludingNilValues() -> [Key: Any] {
+    return compactMapValues { value -> Any? in
+      value is NSNull ? nil : value
+    }
+  }
+}
+
+{% if param.shouldGenerateType %}
+{{accessModifier}} struct {{eventClassName}} {
+  {{accessModifier}} let name: String
+  {{accessModifier}} let parameters: [String: Any]
+
+  {{accessModifier}} init(name: String, parameters: [String: Any] = [:]) {
+    self.name = name
+    self.parameters = parameters
+  }
+}
+{% endif %}
 {% else %}
 // No files found
 {% endif %}
-
-private extension Dictionary where Value == Any? {
-    /// Returns dictionary with filtered out `nil` and `NSNull` values
-    func byExcludingNilValues() -> [Key: Any] {
-        return compactMapValues { value -> Any? in
-            value is NSNull ? nil : value
-        }
-    }
-} 
 // swiftlint:enable all

--- a/Sources/Services/AuthTokenService/AuthError.swift
+++ b/Sources/Services/AuthTokenService/AuthError.swift
@@ -10,7 +10,7 @@ import Foundation
 enum AuthError: LocalizedError {
     case keychainError(String)
     case tokenNotFound
-    
+
     var errorDescription: String? {
         switch self {
         case .keychainError(let message):

--- a/Sources/Services/AuthTokenService/KeychainAuthTokenService.swift
+++ b/Sources/Services/AuthTokenService/KeychainAuthTokenService.swift
@@ -9,7 +9,7 @@ import Foundation
 
 final class KeychainAuthTokenService: AuthTokenService {
     private let service = "net.eventpanel.cli"
-    
+
     private func accountIdentifier(for workspaceId: String?) -> String {
         if let workspaceId = workspaceId {
             return "api-token-\(workspaceId)"
@@ -17,7 +17,7 @@ final class KeychainAuthTokenService: AuthTokenService {
             return "api-token" // fallback for backward compatibility
         }
     }
-    
+
     func setToken(_ token: String, workspaceId: String? = nil) async throws {
         let account = accountIdentifier(for: workspaceId)
 
@@ -27,16 +27,16 @@ final class KeychainAuthTokenService: AuthTokenService {
             kSecAttrAccount as String: account,
             kSecValueData as String: token.data(using: .utf8)!
         ]
-        
+
         // First try to delete any existing token for this workspace
         SecItemDelete(query as CFDictionary)
-        
+
         let status = SecItemAdd(query as CFDictionary, nil)
         guard status == errSecSuccess else {
             throw AuthError.keychainError("Failed to save token: \(status)")
         }
     }
-    
+
     func getToken(workspaceId: String? = nil) throws -> String {
         let account = accountIdentifier(for: workspaceId)
 
@@ -46,19 +46,19 @@ final class KeychainAuthTokenService: AuthTokenService {
             kSecAttrAccount as String: account,
             kSecReturnData as String: true
         ]
-        
+
         var result: AnyObject?
         let status = SecItemCopyMatching(query as CFDictionary, &result)
-        
+
         guard status == errSecSuccess,
               let data = result as? Data,
               let token = String(data: data, encoding: .utf8) else {
             throw AuthError.tokenNotFound
         }
-        
+
         return token
     }
-    
+
     func removeToken(workspaceId: String? = nil) async throws {
         let account = accountIdentifier(for: workspaceId)
 
@@ -67,7 +67,7 @@ final class KeychainAuthTokenService: AuthTokenService {
             kSecAttrService as String: service,
             kSecAttrAccount as String: account
         ]
-        
+
         let status = SecItemDelete(query as CFDictionary)
         guard status == errSecSuccess || status == errSecItemNotFound else {
             throw AuthError.keychainError("Failed to remove token: \(status)")

--- a/Sources/Services/ConfigProvider.swift
+++ b/Sources/Services/ConfigProvider.swift
@@ -16,7 +16,7 @@ final class FileConfigProvider: @unchecked Sendable, ConfigProvider {
         self.configFileLocation = configFileLocation
         self.fileManager = fileManager
     }
-    
+
     func getEventPanelYaml() async throws -> EventPanelYaml {
         let eventPanelYaml = try EventPanelYaml(path: configFileLocation.configFilePath.relativePath)
         return eventPanelYaml

--- a/Sources/Services/NetworkClient/EventPanelAPIService.swift
+++ b/Sources/Services/NetworkClient/EventPanelAPIService.swift
@@ -7,10 +7,10 @@ final class EventPanelAPIService {
     init(networkClient: NetworkClient) {
         self.networkClient = networkClient
     }
-    
+
     enum EventPanelError: LocalizedError {
         case invalidSource(String)
-        
+
         var errorDescription: String? {
             switch self {
             case .invalidSource(let message):

--- a/Sources/Services/NetworkClient/Models/LocalEventDefenitionData.swift
+++ b/Sources/Services/NetworkClient/Models/LocalEventDefenitionData.swift
@@ -5,7 +5,6 @@
 //  Created by Sukhanov Evgenii on 26.05.2025.
 //
 
-
 struct LocalEventDefenitionData: Codable {
     let eventId: String
     let version: Int

--- a/Sources/Services/NetworkClient/NetworkClient.swift
+++ b/Sources/Services/NetworkClient/NetworkClient.swift
@@ -18,7 +18,7 @@ final class AuthAPIClientDelegate: APIClientDelegate, Sendable {
            let bodyString = String(data: body, encoding: .utf8) {
             ConsoleLogger.debug("Request Body: \(bodyString)")
         }
-        
+
         let token = try await authTokenProvider.getToken()
         request.setValue(token, forHTTPHeaderField: "x-api-key")
     }

--- a/Sources/Services/OutputPathValidator.swift
+++ b/Sources/Services/OutputPathValidator.swift
@@ -6,11 +6,11 @@ protocol OutputPathValidator {
 
 final class DefaultOutputPathValidator: OutputPathValidator {
     private let fileManager: FileManager
-    
+
     init(fileManager: FileManager = .default) {
         self.fileManager = fileManager
     }
-    
+
     func validate(
         _ outputPath: String,
         for source: Source,
@@ -20,37 +20,37 @@ final class DefaultOutputPathValidator: OutputPathValidator {
         guard !outputPath.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
             throw OutputPathValidationError.emptyOutputPath
         }
-        
+
         let trimmedPath = outputPath.trimmingCharacters(in: .whitespacesAndNewlines)
-        
+
         // Create the full URL by combining working directory with the output path
         let fullURL = workingDirectory.appendingPathComponent(trimmedPath)
-        
+
         // Validate that the path is nested within the working directory
         guard fullURL.path.hasPrefix(workingDirectory.path) else {
             throw OutputPathValidationError.notNestedPath(workingDirectory)
         }
-        
+
         // Extract the file name from the path
         let fileName = fullURL.lastPathComponent
-        
+
         // Validate the file name based on the source platform
         try validateFileName(fileName, for: source)
-        
+
         // Create the directory path (parent directory of the file)
         let directoryURL = fullURL.deletingLastPathComponent()
-        
+
         // Check if the directory can be created or already exists
         do {
             try fileManager.createDirectory(at: directoryURL, withIntermediateDirectories: true, attributes: nil)
         } catch {
             throw OutputPathValidationError.invalidPath(directoryURL)
         }
-        
+
         // Return the validated path
         return trimmedPath
     }
-    
+
     private func validateFileName(_ fileName: String, for source: Source) throws {
         switch source {
         case .iOS:
@@ -65,7 +65,7 @@ enum OutputPathValidationError: LocalizedError {
     case emptyOutputPath
     case notNestedPath(URL)
     case invalidPath(URL)
-    
+
     var errorDescription: String? {
         switch self {
         case .emptyOutputPath:
@@ -83,12 +83,12 @@ extension URL {
     func relativePath(from baseURL: URL) -> String {
         let basePath = baseURL.path
         let currentPath = self.path
-        
+
         if currentPath.hasPrefix(basePath) {
             let relativePath = String(currentPath.dropFirst(basePath.count))
             return relativePath.hasPrefix("/") ? String(relativePath.dropFirst()) : relativePath
         }
-        
+
         return currentPath
     }
 }

--- a/Sources/Utils/ConsoleLogger.swift
+++ b/Sources/Utils/ConsoleLogger.swift
@@ -1,11 +1,11 @@
-actor ConsoleLogger {
+final class ConsoleLogger {
     private static let red = "\u{001B}[31m"
     private static let green = "\u{001B}[32m"
     private static let yellow = "\u{001B}[33m"
     private static let reset = "\u{001B}[0m"
 
-    static var isVerbose = false
-    
+    nonisolated(unsafe) static var isVerbose = false
+
     static func error(
         _ message: String,
         separator: String = " ",

--- a/Sources/Utils/ConsoleLogger.swift
+++ b/Sources/Utils/ConsoleLogger.swift
@@ -13,7 +13,7 @@ final class ConsoleLogger {
     ) {
         print("\(red)[!] \(message)\(reset)", separator: separator, terminator: terminator)
     }
-    
+
     static func success(
         _ message: String,
         separator: String = " ",
@@ -21,7 +21,7 @@ final class ConsoleLogger {
     ) {
         print("\(green)\(message)\(reset)", separator: separator, terminator: terminator)
     }
-    
+
     static func warning(
         _ message: String,
         separator: String = " ",
@@ -29,7 +29,7 @@ final class ConsoleLogger {
     ) {
         print("\(yellow)[!] \(message)\(reset)", separator: separator, terminator: terminator)
     }
-    
+
     static func message(
         _ message: String,
         separator: String = " ",

--- a/Tests/EventPanelCLITests/KotlinFileNameValidatorTests.swift
+++ b/Tests/EventPanelCLITests/KotlinFileNameValidatorTests.swift
@@ -6,140 +6,106 @@ final class KotlinFileNameValidatorTests: XCTestCase {
     // MARK: - Valid File Names
     
     func testValidFileName() throws {
-        // Given
         let fileName = "Events.kt"
         
-        // When & Then
         XCTAssertNoThrow(try KotlinFileNameValidator.validate(fileName))
     }
     
     func testValidFileNameWithUnderscore() throws {
-        // Given
         let fileName = "Analytics_Events.kt"
         
-        // When & Then
         XCTAssertNoThrow(try KotlinFileNameValidator.validate(fileName))
     }
     
     func testValidFileNameWithNumbers() throws {
-        // Given
         let fileName = "Event2.kt"
         
-        // When & Then
         XCTAssertNoThrow(try KotlinFileNameValidator.validate(fileName))
     }
     
     func testValidFileNameStartingWithUnderscore() throws {
-        // Given
         let fileName = "_PrivateEvents.kt"
         
-        // When & Then
         XCTAssertNoThrow(try KotlinFileNameValidator.validate(fileName))
     }
     
     func testValidFileNameStartingWithDollarSign() throws {
-        // Given
         let fileName = "$GeneratedEvents.kt"
         
-        // When & Then
         XCTAssertNoThrow(try KotlinFileNameValidator.validate(fileName))
     }
     
     func testValidFileNameWithDollarSign() throws {
-        // Given
         let fileName = "Events$Test.kt"
         
-        // When & Then
         XCTAssertNoThrow(try KotlinFileNameValidator.validate(fileName))
     }
     
     func testValidFileNameWithHyphen() throws {
-        // Given
         let fileName = "Events-File.kt"
         
-        // When & Then
         XCTAssertNoThrow(try KotlinFileNameValidator.validate(fileName))
     }
     
     func testValidFileNameWithPeriod() throws {
-        // Given
         let fileName = "Events.File.kt"
         
-        // When & Then
         XCTAssertNoThrow(try KotlinFileNameValidator.validate(fileName))
     }
     
     func testValidFileNameWithMultiplePeriods() throws {
-        // Given
         let fileName = "Events.File.Utils.kt"
         
-        // When & Then
         XCTAssertNoThrow(try KotlinFileNameValidator.validate(fileName))
     }
     
     func testValidFileNameWithPlus() throws {
-        // Given
         let fileName = "Events+File.kt"
         
-        // When & Then
         XCTAssertNoThrow(try KotlinFileNameValidator.validate(fileName))
     }
     
     func testValidFileNameWithSpace() throws {
-        // Given
         let fileName = "Events File.kt"
         
-        // When & Then
         XCTAssertNoThrow(try KotlinFileNameValidator.validate(fileName))
     }
     
     func testValidFileNameWithAtSign() throws {
-        // Given
         let fileName = "Events@File.kt"
         
-        // When & Then
         XCTAssertNoThrow(try KotlinFileNameValidator.validate(fileName))
     }
     
     func testValidFileNameWithHash() throws {
-        // Given
         let fileName = "Events#File.kt"
         
-        // When & Then
         XCTAssertNoThrow(try KotlinFileNameValidator.validate(fileName))
     }
     
     func testValidFileNameWithPercent() throws {
-        // Given
         let fileName = "Events%File.kt"
         
-        // When & Then
         XCTAssertNoThrow(try KotlinFileNameValidator.validate(fileName))
     }
     
     func testValidFileNameWithExclamation() throws {
-        // Given
         let fileName = "Events!File.kt"
         
-        // When & Then
         XCTAssertNoThrow(try KotlinFileNameValidator.validate(fileName))
     }
     
     func testValidFileNameWithWhitespace() throws {
-        // Given
         let fileName = "  Events.kt  "
         
-        // When & Then
         XCTAssertNoThrow(try KotlinFileNameValidator.validate(fileName))
     }
     
     // MARK: - Empty File Name Tests
     
     func testEmptyFileName() {
-        // Given
         let fileName = ""
         
-        // When & Then
         XCTAssertThrowsError(try KotlinFileNameValidator.validate(fileName)) { error in
             XCTAssertTrue(error is KotlinFileNameValidationError)
             if case KotlinFileNameValidationError.emptyFileName = error {
@@ -151,10 +117,8 @@ final class KotlinFileNameValidatorTests: XCTestCase {
     }
     
     func testWhitespaceOnlyFileName() {
-        // Given
         let fileName = "   "
         
-        // When & Then
         XCTAssertThrowsError(try KotlinFileNameValidator.validate(fileName)) { error in
             XCTAssertTrue(error is KotlinFileNameValidationError)
             if case KotlinFileNameValidationError.emptyFileName = error {
@@ -166,10 +130,8 @@ final class KotlinFileNameValidatorTests: XCTestCase {
     }
     
     func testNewlineOnlyFileName() {
-        // Given
         let fileName = "\n\t"
         
-        // When & Then
         XCTAssertThrowsError(try KotlinFileNameValidator.validate(fileName)) { error in
             XCTAssertTrue(error is KotlinFileNameValidationError)
             if case KotlinFileNameValidationError.emptyFileName = error {
@@ -183,10 +145,8 @@ final class KotlinFileNameValidatorTests: XCTestCase {
     // MARK: - Missing Extension Tests
     
     func testMissingKotlinExtension() {
-        // Given
         let fileName = "Events"
         
-        // When & Then
         XCTAssertThrowsError(try KotlinFileNameValidator.validate(fileName)) { error in
             XCTAssertTrue(error is KotlinFileNameValidationError)
             if case KotlinFileNameValidationError.missingKotlinExtension = error {
@@ -198,10 +158,8 @@ final class KotlinFileNameValidatorTests: XCTestCase {
     }
     
     func testWrongExtension() {
-        // Given
         let fileName = "Events.txt"
         
-        // When & Then
         XCTAssertThrowsError(try KotlinFileNameValidator.validate(fileName)) { error in
             XCTAssertTrue(error is KotlinFileNameValidationError)
             if case KotlinFileNameValidationError.missingKotlinExtension = error {
@@ -213,10 +171,8 @@ final class KotlinFileNameValidatorTests: XCTestCase {
     }
     
     func testCaseSensitiveExtension() {
-        // Given
         let fileName = "Events.KT"
         
-        // When & Then
         XCTAssertThrowsError(try KotlinFileNameValidator.validate(fileName)) { error in
             XCTAssertTrue(error is KotlinFileNameValidationError)
             if case KotlinFileNameValidationError.missingKotlinExtension = error {
@@ -230,10 +186,8 @@ final class KotlinFileNameValidatorTests: XCTestCase {
     // MARK: - Empty Base Name Tests
     
     func testEmptyBaseName() {
-        // Given
         let fileName = ".kt"
         
-        // When & Then
         XCTAssertThrowsError(try KotlinFileNameValidator.validate(fileName)) { error in
             XCTAssertTrue(error is KotlinFileNameValidationError)
             if case KotlinFileNameValidationError.emptyBaseName = error {
@@ -245,10 +199,8 @@ final class KotlinFileNameValidatorTests: XCTestCase {
     }
     
     func testWhitespaceBaseName() {
-        // Given
         let fileName = "   .kt"
         
-        // When & Then
         XCTAssertThrowsError(try KotlinFileNameValidator.validate(fileName)) { error in
             XCTAssertTrue(error is KotlinFileNameValidationError)
             if case KotlinFileNameValidationError.emptyBaseName = error {
@@ -262,10 +214,8 @@ final class KotlinFileNameValidatorTests: XCTestCase {
     // MARK: - Invalid Start Character Tests
     
     func testInvalidStartCharacterNumber() {
-        // Given
         let fileName = "2Events.kt"
         
-        // When & Then
         XCTAssertThrowsError(try KotlinFileNameValidator.validate(fileName)) { error in
             XCTAssertTrue(error is KotlinFileNameValidationError)
             if case KotlinFileNameValidationError.invalidStartCharacter = error {
@@ -277,10 +227,8 @@ final class KotlinFileNameValidatorTests: XCTestCase {
     }
     
     func testInvalidStartCharacterSpecialChar() {
-        // Given
         let fileName = "@Events.kt"
         
-        // When & Then
         XCTAssertThrowsError(try KotlinFileNameValidator.validate(fileName)) { error in
             XCTAssertTrue(error is KotlinFileNameValidationError)
             if case KotlinFileNameValidationError.invalidStartCharacter = error {
@@ -292,10 +240,8 @@ final class KotlinFileNameValidatorTests: XCTestCase {
     }
     
     func testInvalidStartCharacterHyphen() {
-        // Given
         let fileName = "-Events.kt"
         
-        // When & Then
         XCTAssertThrowsError(try KotlinFileNameValidator.validate(fileName)) { error in
             XCTAssertTrue(error is KotlinFileNameValidationError)
             if case KotlinFileNameValidationError.invalidStartCharacter = error {
@@ -310,10 +256,8 @@ final class KotlinFileNameValidatorTests: XCTestCase {
     
     
     func testInvalidCharactersColon() {
-        // Given
         let fileName = "Events:File.kt"
         
-        // When & Then
         XCTAssertThrowsError(try KotlinFileNameValidator.validate(fileName)) { error in
             XCTAssertTrue(error is KotlinFileNameValidationError)
             if case KotlinFileNameValidationError.invalidCharacters = error {
@@ -325,10 +269,8 @@ final class KotlinFileNameValidatorTests: XCTestCase {
     }
     
     func testInvalidCharactersSlash() {
-        // Given
         let fileName = "Events/File.kt"
         
-        // When & Then
         XCTAssertThrowsError(try KotlinFileNameValidator.validate(fileName)) { error in
             XCTAssertTrue(error is KotlinFileNameValidationError)
             if case KotlinFileNameValidationError.invalidCharacters = error {
@@ -340,10 +282,8 @@ final class KotlinFileNameValidatorTests: XCTestCase {
     }
     
     func testInvalidCharactersBackslash() {
-        // Given
         let fileName = "Events\\File.kt"
         
-        // When & Then
         XCTAssertThrowsError(try KotlinFileNameValidator.validate(fileName)) { error in
             XCTAssertTrue(error is KotlinFileNameValidationError)
             if case KotlinFileNameValidationError.invalidCharacters = error {
@@ -355,10 +295,8 @@ final class KotlinFileNameValidatorTests: XCTestCase {
     }
     
     func testInvalidCharactersQuestionMark() {
-        // Given
         let fileName = "Events?File.kt"
         
-        // When & Then
         XCTAssertThrowsError(try KotlinFileNameValidator.validate(fileName)) { error in
             XCTAssertTrue(error is KotlinFileNameValidationError)
             if case KotlinFileNameValidationError.invalidCharacters = error {
@@ -370,10 +308,8 @@ final class KotlinFileNameValidatorTests: XCTestCase {
     }
     
     func testInvalidCharactersAsterisk() {
-        // Given
         let fileName = "Events*File.kt"
         
-        // When & Then
         XCTAssertThrowsError(try KotlinFileNameValidator.validate(fileName)) { error in
             XCTAssertTrue(error is KotlinFileNameValidationError)
             if case KotlinFileNameValidationError.invalidCharacters = error {
@@ -385,10 +321,8 @@ final class KotlinFileNameValidatorTests: XCTestCase {
     }
     
     func testInvalidCharactersQuote() {
-        // Given
         let fileName = "Events\"File.kt"
         
-        // When & Then
         XCTAssertThrowsError(try KotlinFileNameValidator.validate(fileName)) { error in
             XCTAssertTrue(error is KotlinFileNameValidationError)
             if case KotlinFileNameValidationError.invalidCharacters = error {
@@ -400,10 +334,8 @@ final class KotlinFileNameValidatorTests: XCTestCase {
     }
     
     func testInvalidCharactersLessThan() {
-        // Given
         let fileName = "Events<File.kt"
         
-        // When & Then
         XCTAssertThrowsError(try KotlinFileNameValidator.validate(fileName)) { error in
             XCTAssertTrue(error is KotlinFileNameValidationError)
             if case KotlinFileNameValidationError.invalidCharacters = error {
@@ -415,10 +347,8 @@ final class KotlinFileNameValidatorTests: XCTestCase {
     }
     
     func testInvalidCharactersGreaterThan() {
-        // Given
         let fileName = "Events>File.kt"
         
-        // When & Then
         XCTAssertThrowsError(try KotlinFileNameValidator.validate(fileName)) { error in
             XCTAssertTrue(error is KotlinFileNameValidationError)
             if case KotlinFileNameValidationError.invalidCharacters = error {
@@ -430,10 +360,8 @@ final class KotlinFileNameValidatorTests: XCTestCase {
     }
     
     func testInvalidCharactersPipe() {
-        // Given
         let fileName = "Events|File.kt"
         
-        // When & Then
         XCTAssertThrowsError(try KotlinFileNameValidator.validate(fileName)) { error in
             XCTAssertTrue(error is KotlinFileNameValidationError)
             if case KotlinFileNameValidationError.invalidCharacters = error {
@@ -447,228 +375,172 @@ final class KotlinFileNameValidatorTests: XCTestCase {
     // MARK: - Valid Reserved Keyword File Names (These should now be valid)
     
     func testValidReservedKeywordClass() throws {
-        // Given
         let fileName = "class.kt"
         
-        // When & Then
         XCTAssertNoThrow(try KotlinFileNameValidator.validate(fileName))
     }
     
     func testValidReservedKeywordFun() throws {
-        // Given
         let fileName = "fun.kt"
         
-        // When & Then
         XCTAssertNoThrow(try KotlinFileNameValidator.validate(fileName))
     }
     
     func testValidReservedKeywordData() throws {
-        // Given
         let fileName = "data.kt"
         
-        // When & Then
         XCTAssertNoThrow(try KotlinFileNameValidator.validate(fileName))
     }
     
     func testValidReservedKeywordEnum() throws {
-        // Given
         let fileName = "enum.kt"
         
-        // When & Then
         XCTAssertNoThrow(try KotlinFileNameValidator.validate(fileName))
     }
     
     func testValidReservedKeywordInterface() throws {
-        // Given
         let fileName = "interface.kt"
         
-        // When & Then
         XCTAssertNoThrow(try KotlinFileNameValidator.validate(fileName))
     }
     
     func testValidReservedKeywordPackage() throws {
-        // Given
         let fileName = "package.kt"
         
-        // When & Then
         XCTAssertNoThrow(try KotlinFileNameValidator.validate(fileName))
     }
     
     func testValidReservedKeywordImport() throws {
-        // Given
         let fileName = "import.kt"
         
-        // When & Then
         XCTAssertNoThrow(try KotlinFileNameValidator.validate(fileName))
     }
     
     func testValidReservedKeywordVal() throws {
-        // Given
         let fileName = "val.kt"
         
-        // When & Then
         XCTAssertNoThrow(try KotlinFileNameValidator.validate(fileName))
     }
     
     func testValidReservedKeywordVar() throws {
-        // Given
         let fileName = "var.kt"
         
-        // When & Then
         XCTAssertNoThrow(try KotlinFileNameValidator.validate(fileName))
     }
     
     func testValidReservedKeywordIf() throws {
-        // Given
         let fileName = "if.kt"
         
-        // When & Then
         XCTAssertNoThrow(try KotlinFileNameValidator.validate(fileName))
     }
     
     func testValidReservedKeywordFor() throws {
-        // Given
         let fileName = "for.kt"
         
-        // When & Then
         XCTAssertNoThrow(try KotlinFileNameValidator.validate(fileName))
     }
     
     func testValidReservedKeywordWhile() throws {
-        // Given
         let fileName = "while.kt"
         
-        // When & Then
         XCTAssertNoThrow(try KotlinFileNameValidator.validate(fileName))
     }
     
     func testValidReservedKeywordReturn() throws {
-        // Given
         let fileName = "return.kt"
         
-        // When & Then
         XCTAssertNoThrow(try KotlinFileNameValidator.validate(fileName))
     }
     
     func testValidReservedKeywordTrue() throws {
-        // Given
         let fileName = "true.kt"
         
-        // When & Then
         XCTAssertNoThrow(try KotlinFileNameValidator.validate(fileName))
     }
     
     func testValidReservedKeywordFalse() throws {
-        // Given
         let fileName = "false.kt"
         
-        // When & Then
         XCTAssertNoThrow(try KotlinFileNameValidator.validate(fileName))
     }
     
     func testValidReservedKeywordNull() throws {
-        // Given
         let fileName = "null.kt"
         
-        // When & Then
         XCTAssertNoThrow(try KotlinFileNameValidator.validate(fileName))
     }
     
     func testValidReservedKeywordWhen() throws {
-        // Given
         let fileName = "when.kt"
         
-        // When & Then
         XCTAssertNoThrow(try KotlinFileNameValidator.validate(fileName))
     }
     
     func testValidReservedKeywordObject() throws {
-        // Given
         let fileName = "object.kt"
         
-        // When & Then
         XCTAssertNoThrow(try KotlinFileNameValidator.validate(fileName))
     }
     
     func testValidReservedKeywordCompanion() throws {
-        // Given
         let fileName = "companion.kt"
         
-        // When & Then
         XCTAssertNoThrow(try KotlinFileNameValidator.validate(fileName))
     }
     
     func testValidReservedKeywordSealed() throws {
-        // Given
         let fileName = "sealed.kt"
         
-        // When & Then
         XCTAssertNoThrow(try KotlinFileNameValidator.validate(fileName))
     }
     
     func testValidReservedKeywordAbstract() throws {
-        // Given
         let fileName = "abstract.kt"
         
-        // When & Then
         XCTAssertNoThrow(try KotlinFileNameValidator.validate(fileName))
     }
     
     func testValidReservedKeywordOpen() throws {
-        // Given
         let fileName = "open.kt"
         
-        // When & Then
         XCTAssertNoThrow(try KotlinFileNameValidator.validate(fileName))
     }
     
     func testValidReservedKeywordInternal() throws {
-        // Given
         let fileName = "internal.kt"
         
-        // When & Then
         XCTAssertNoThrow(try KotlinFileNameValidator.validate(fileName))
     }
     
     func testValidReservedKeywordPrivate() throws {
-        // Given
         let fileName = "private.kt"
         
-        // When & Then
         XCTAssertNoThrow(try KotlinFileNameValidator.validate(fileName))
     }
     
     func testValidReservedKeywordProtected() throws {
-        // Given
         let fileName = "protected.kt"
         
-        // When & Then
         XCTAssertNoThrow(try KotlinFileNameValidator.validate(fileName))
     }
     
     func testValidReservedKeywordPublic() throws {
-        // Given
         let fileName = "public.kt"
         
-        // When & Then
         XCTAssertNoThrow(try KotlinFileNameValidator.validate(fileName))
     }
     
     // MARK: - Edge Cases
     
     func testVeryLongValidFileName() throws {
-        // Given
         let fileName = String(repeating: "A", count: 100) + ".kt"
         
-        // When & Then
         XCTAssertNoThrow(try KotlinFileNameValidator.validate(fileName))
     }
     
     func testFileNameWithOnlyUnderscores() throws {
-        // Given
         let fileName = "___"
         
-        // When & Then
         XCTAssertThrowsError(try KotlinFileNameValidator.validate(fileName)) { error in
             XCTAssertTrue(error is KotlinFileNameValidationError)
             if case KotlinFileNameValidationError.missingKotlinExtension = error {
@@ -680,18 +552,14 @@ final class KotlinFileNameValidatorTests: XCTestCase {
     }
     
     func testFileNameWithOnlyUnderscoresAndExtension() throws {
-        // Given
         let fileName = "___.kt"
         
-        // When & Then
         XCTAssertNoThrow(try KotlinFileNameValidator.validate(fileName))
     }
     
     func testFileNameWithOnlyDollarSigns() throws {
-        // Given
         let fileName = "$$$"
         
-        // When & Then
         XCTAssertThrowsError(try KotlinFileNameValidator.validate(fileName)) { error in
             XCTAssertTrue(error is KotlinFileNameValidationError)
             if case KotlinFileNameValidationError.missingKotlinExtension = error {
@@ -703,34 +571,26 @@ final class KotlinFileNameValidatorTests: XCTestCase {
     }
     
     func testFileNameWithOnlyDollarSignsAndExtension() throws {
-        // Given
         let fileName = "$$$.kt"
         
-        // When & Then
         XCTAssertNoThrow(try KotlinFileNameValidator.validate(fileName))
     }
     
     func testFileNameWithNumbersAndUnderscores() throws {
-        // Given
         let fileName = "Event_123_Test.kt"
         
-        // When & Then
         XCTAssertNoThrow(try KotlinFileNameValidator.validate(fileName))
     }
     
     func testFileNameWithNumbersAndDollarSigns() throws {
-        // Given
         let fileName = "Event$123$Test.kt"
         
-        // When & Then
         XCTAssertNoThrow(try KotlinFileNameValidator.validate(fileName))
     }
     
     func testFileNameWithMixedValidCharacters() throws {
-        // Given
         let fileName = "Event_123$Test_456.kt"
         
-        // When & Then
         XCTAssertNoThrow(try KotlinFileNameValidator.validate(fileName))
     }
 }

--- a/Tests/EventPanelCLITests/KotlinFileNameValidatorTests.swift
+++ b/Tests/EventPanelCLITests/KotlinFileNameValidatorTests.swift
@@ -2,110 +2,110 @@ import XCTest
 @testable import eventpanel
 
 final class KotlinFileNameValidatorTests: XCTestCase {
-    
+
     // MARK: - Valid File Names
-    
+
     func testValidFileName() throws {
         let fileName = "Events.kt"
-        
+
         XCTAssertNoThrow(try KotlinFileNameValidator.validate(fileName))
     }
-    
+
     func testValidFileNameWithUnderscore() throws {
         let fileName = "Analytics_Events.kt"
-        
+
         XCTAssertNoThrow(try KotlinFileNameValidator.validate(fileName))
     }
-    
+
     func testValidFileNameWithNumbers() throws {
         let fileName = "Event2.kt"
-        
+
         XCTAssertNoThrow(try KotlinFileNameValidator.validate(fileName))
     }
-    
+
     func testValidFileNameStartingWithUnderscore() throws {
         let fileName = "_PrivateEvents.kt"
-        
+
         XCTAssertNoThrow(try KotlinFileNameValidator.validate(fileName))
     }
-    
+
     func testValidFileNameStartingWithDollarSign() throws {
         let fileName = "$GeneratedEvents.kt"
-        
+
         XCTAssertNoThrow(try KotlinFileNameValidator.validate(fileName))
     }
-    
+
     func testValidFileNameWithDollarSign() throws {
         let fileName = "Events$Test.kt"
-        
+
         XCTAssertNoThrow(try KotlinFileNameValidator.validate(fileName))
     }
-    
+
     func testValidFileNameWithHyphen() throws {
         let fileName = "Events-File.kt"
-        
+
         XCTAssertNoThrow(try KotlinFileNameValidator.validate(fileName))
     }
-    
+
     func testValidFileNameWithPeriod() throws {
         let fileName = "Events.File.kt"
-        
+
         XCTAssertNoThrow(try KotlinFileNameValidator.validate(fileName))
     }
-    
+
     func testValidFileNameWithMultiplePeriods() throws {
         let fileName = "Events.File.Utils.kt"
-        
+
         XCTAssertNoThrow(try KotlinFileNameValidator.validate(fileName))
     }
-    
+
     func testValidFileNameWithPlus() throws {
         let fileName = "Events+File.kt"
-        
+
         XCTAssertNoThrow(try KotlinFileNameValidator.validate(fileName))
     }
-    
+
     func testValidFileNameWithSpace() throws {
         let fileName = "Events File.kt"
-        
+
         XCTAssertNoThrow(try KotlinFileNameValidator.validate(fileName))
     }
-    
+
     func testValidFileNameWithAtSign() throws {
         let fileName = "Events@File.kt"
-        
+
         XCTAssertNoThrow(try KotlinFileNameValidator.validate(fileName))
     }
-    
+
     func testValidFileNameWithHash() throws {
         let fileName = "Events#File.kt"
-        
+
         XCTAssertNoThrow(try KotlinFileNameValidator.validate(fileName))
     }
-    
+
     func testValidFileNameWithPercent() throws {
         let fileName = "Events%File.kt"
-        
+
         XCTAssertNoThrow(try KotlinFileNameValidator.validate(fileName))
     }
-    
+
     func testValidFileNameWithExclamation() throws {
         let fileName = "Events!File.kt"
-        
+
         XCTAssertNoThrow(try KotlinFileNameValidator.validate(fileName))
     }
-    
+
     func testValidFileNameWithWhitespace() throws {
         let fileName = "  Events.kt  "
-        
+
         XCTAssertNoThrow(try KotlinFileNameValidator.validate(fileName))
     }
-    
+
     // MARK: - Empty File Name Tests
-    
+
     func testEmptyFileName() {
         let fileName = ""
-        
+
         XCTAssertThrowsError(try KotlinFileNameValidator.validate(fileName)) { error in
             XCTAssertTrue(error is KotlinFileNameValidationError)
             if case KotlinFileNameValidationError.emptyFileName = error {
@@ -115,10 +115,10 @@ final class KotlinFileNameValidatorTests: XCTestCase {
             }
         }
     }
-    
+
     func testWhitespaceOnlyFileName() {
         let fileName = "   "
-        
+
         XCTAssertThrowsError(try KotlinFileNameValidator.validate(fileName)) { error in
             XCTAssertTrue(error is KotlinFileNameValidationError)
             if case KotlinFileNameValidationError.emptyFileName = error {
@@ -128,10 +128,10 @@ final class KotlinFileNameValidatorTests: XCTestCase {
             }
         }
     }
-    
+
     func testNewlineOnlyFileName() {
         let fileName = "\n\t"
-        
+
         XCTAssertThrowsError(try KotlinFileNameValidator.validate(fileName)) { error in
             XCTAssertTrue(error is KotlinFileNameValidationError)
             if case KotlinFileNameValidationError.emptyFileName = error {
@@ -141,12 +141,12 @@ final class KotlinFileNameValidatorTests: XCTestCase {
             }
         }
     }
-    
+
     // MARK: - Missing Extension Tests
-    
+
     func testMissingKotlinExtension() {
         let fileName = "Events"
-        
+
         XCTAssertThrowsError(try KotlinFileNameValidator.validate(fileName)) { error in
             XCTAssertTrue(error is KotlinFileNameValidationError)
             if case KotlinFileNameValidationError.missingKotlinExtension = error {
@@ -156,10 +156,10 @@ final class KotlinFileNameValidatorTests: XCTestCase {
             }
         }
     }
-    
+
     func testWrongExtension() {
         let fileName = "Events.txt"
-        
+
         XCTAssertThrowsError(try KotlinFileNameValidator.validate(fileName)) { error in
             XCTAssertTrue(error is KotlinFileNameValidationError)
             if case KotlinFileNameValidationError.missingKotlinExtension = error {
@@ -169,10 +169,10 @@ final class KotlinFileNameValidatorTests: XCTestCase {
             }
         }
     }
-    
+
     func testCaseSensitiveExtension() {
         let fileName = "Events.KT"
-        
+
         XCTAssertThrowsError(try KotlinFileNameValidator.validate(fileName)) { error in
             XCTAssertTrue(error is KotlinFileNameValidationError)
             if case KotlinFileNameValidationError.missingKotlinExtension = error {
@@ -182,12 +182,12 @@ final class KotlinFileNameValidatorTests: XCTestCase {
             }
         }
     }
-    
+
     // MARK: - Empty Base Name Tests
-    
+
     func testEmptyBaseName() {
         let fileName = ".kt"
-        
+
         XCTAssertThrowsError(try KotlinFileNameValidator.validate(fileName)) { error in
             XCTAssertTrue(error is KotlinFileNameValidationError)
             if case KotlinFileNameValidationError.emptyBaseName = error {
@@ -197,10 +197,10 @@ final class KotlinFileNameValidatorTests: XCTestCase {
             }
         }
     }
-    
+
     func testWhitespaceBaseName() {
         let fileName = "   .kt"
-        
+
         XCTAssertThrowsError(try KotlinFileNameValidator.validate(fileName)) { error in
             XCTAssertTrue(error is KotlinFileNameValidationError)
             if case KotlinFileNameValidationError.emptyBaseName = error {
@@ -210,12 +210,12 @@ final class KotlinFileNameValidatorTests: XCTestCase {
             }
         }
     }
-    
+
     // MARK: - Invalid Start Character Tests
-    
+
     func testInvalidStartCharacterNumber() {
         let fileName = "2Events.kt"
-        
+
         XCTAssertThrowsError(try KotlinFileNameValidator.validate(fileName)) { error in
             XCTAssertTrue(error is KotlinFileNameValidationError)
             if case KotlinFileNameValidationError.invalidStartCharacter = error {
@@ -225,10 +225,10 @@ final class KotlinFileNameValidatorTests: XCTestCase {
             }
         }
     }
-    
+
     func testInvalidStartCharacterSpecialChar() {
         let fileName = "@Events.kt"
-        
+
         XCTAssertThrowsError(try KotlinFileNameValidator.validate(fileName)) { error in
             XCTAssertTrue(error is KotlinFileNameValidationError)
             if case KotlinFileNameValidationError.invalidStartCharacter = error {
@@ -238,10 +238,10 @@ final class KotlinFileNameValidatorTests: XCTestCase {
             }
         }
     }
-    
+
     func testInvalidStartCharacterHyphen() {
         let fileName = "-Events.kt"
-        
+
         XCTAssertThrowsError(try KotlinFileNameValidator.validate(fileName)) { error in
             XCTAssertTrue(error is KotlinFileNameValidationError)
             if case KotlinFileNameValidationError.invalidStartCharacter = error {
@@ -251,13 +251,12 @@ final class KotlinFileNameValidatorTests: XCTestCase {
             }
         }
     }
-    
+
     // MARK: - Invalid Characters Tests (macOS Forbidden Characters)
-    
-    
+
     func testInvalidCharactersColon() {
         let fileName = "Events:File.kt"
-        
+
         XCTAssertThrowsError(try KotlinFileNameValidator.validate(fileName)) { error in
             XCTAssertTrue(error is KotlinFileNameValidationError)
             if case KotlinFileNameValidationError.invalidCharacters = error {
@@ -267,10 +266,10 @@ final class KotlinFileNameValidatorTests: XCTestCase {
             }
         }
     }
-    
+
     func testInvalidCharactersSlash() {
         let fileName = "Events/File.kt"
-        
+
         XCTAssertThrowsError(try KotlinFileNameValidator.validate(fileName)) { error in
             XCTAssertTrue(error is KotlinFileNameValidationError)
             if case KotlinFileNameValidationError.invalidCharacters = error {
@@ -280,10 +279,10 @@ final class KotlinFileNameValidatorTests: XCTestCase {
             }
         }
     }
-    
+
     func testInvalidCharactersBackslash() {
         let fileName = "Events\\File.kt"
-        
+
         XCTAssertThrowsError(try KotlinFileNameValidator.validate(fileName)) { error in
             XCTAssertTrue(error is KotlinFileNameValidationError)
             if case KotlinFileNameValidationError.invalidCharacters = error {
@@ -293,10 +292,10 @@ final class KotlinFileNameValidatorTests: XCTestCase {
             }
         }
     }
-    
+
     func testInvalidCharactersQuestionMark() {
         let fileName = "Events?File.kt"
-        
+
         XCTAssertThrowsError(try KotlinFileNameValidator.validate(fileName)) { error in
             XCTAssertTrue(error is KotlinFileNameValidationError)
             if case KotlinFileNameValidationError.invalidCharacters = error {
@@ -306,10 +305,10 @@ final class KotlinFileNameValidatorTests: XCTestCase {
             }
         }
     }
-    
+
     func testInvalidCharactersAsterisk() {
         let fileName = "Events*File.kt"
-        
+
         XCTAssertThrowsError(try KotlinFileNameValidator.validate(fileName)) { error in
             XCTAssertTrue(error is KotlinFileNameValidationError)
             if case KotlinFileNameValidationError.invalidCharacters = error {
@@ -319,10 +318,10 @@ final class KotlinFileNameValidatorTests: XCTestCase {
             }
         }
     }
-    
+
     func testInvalidCharactersQuote() {
         let fileName = "Events\"File.kt"
-        
+
         XCTAssertThrowsError(try KotlinFileNameValidator.validate(fileName)) { error in
             XCTAssertTrue(error is KotlinFileNameValidationError)
             if case KotlinFileNameValidationError.invalidCharacters = error {
@@ -332,10 +331,10 @@ final class KotlinFileNameValidatorTests: XCTestCase {
             }
         }
     }
-    
+
     func testInvalidCharactersLessThan() {
         let fileName = "Events<File.kt"
-        
+
         XCTAssertThrowsError(try KotlinFileNameValidator.validate(fileName)) { error in
             XCTAssertTrue(error is KotlinFileNameValidationError)
             if case KotlinFileNameValidationError.invalidCharacters = error {
@@ -345,10 +344,10 @@ final class KotlinFileNameValidatorTests: XCTestCase {
             }
         }
     }
-    
+
     func testInvalidCharactersGreaterThan() {
         let fileName = "Events>File.kt"
-        
+
         XCTAssertThrowsError(try KotlinFileNameValidator.validate(fileName)) { error in
             XCTAssertTrue(error is KotlinFileNameValidationError)
             if case KotlinFileNameValidationError.invalidCharacters = error {
@@ -358,10 +357,10 @@ final class KotlinFileNameValidatorTests: XCTestCase {
             }
         }
     }
-    
+
     func testInvalidCharactersPipe() {
         let fileName = "Events|File.kt"
-        
+
         XCTAssertThrowsError(try KotlinFileNameValidator.validate(fileName)) { error in
             XCTAssertTrue(error is KotlinFileNameValidationError)
             if case KotlinFileNameValidationError.invalidCharacters = error {
@@ -371,176 +370,176 @@ final class KotlinFileNameValidatorTests: XCTestCase {
             }
         }
     }
-    
+
     // MARK: - Valid Reserved Keyword File Names (These should now be valid)
-    
+
     func testValidReservedKeywordClass() throws {
         let fileName = "class.kt"
-        
+
         XCTAssertNoThrow(try KotlinFileNameValidator.validate(fileName))
     }
-    
+
     func testValidReservedKeywordFun() throws {
         let fileName = "fun.kt"
-        
+
         XCTAssertNoThrow(try KotlinFileNameValidator.validate(fileName))
     }
-    
+
     func testValidReservedKeywordData() throws {
         let fileName = "data.kt"
-        
+
         XCTAssertNoThrow(try KotlinFileNameValidator.validate(fileName))
     }
-    
+
     func testValidReservedKeywordEnum() throws {
         let fileName = "enum.kt"
-        
+
         XCTAssertNoThrow(try KotlinFileNameValidator.validate(fileName))
     }
-    
+
     func testValidReservedKeywordInterface() throws {
         let fileName = "interface.kt"
-        
+
         XCTAssertNoThrow(try KotlinFileNameValidator.validate(fileName))
     }
-    
+
     func testValidReservedKeywordPackage() throws {
         let fileName = "package.kt"
-        
+
         XCTAssertNoThrow(try KotlinFileNameValidator.validate(fileName))
     }
-    
+
     func testValidReservedKeywordImport() throws {
         let fileName = "import.kt"
-        
+
         XCTAssertNoThrow(try KotlinFileNameValidator.validate(fileName))
     }
-    
+
     func testValidReservedKeywordVal() throws {
         let fileName = "val.kt"
-        
+
         XCTAssertNoThrow(try KotlinFileNameValidator.validate(fileName))
     }
-    
+
     func testValidReservedKeywordVar() throws {
         let fileName = "var.kt"
-        
+
         XCTAssertNoThrow(try KotlinFileNameValidator.validate(fileName))
     }
-    
+
     func testValidReservedKeywordIf() throws {
         let fileName = "if.kt"
-        
+
         XCTAssertNoThrow(try KotlinFileNameValidator.validate(fileName))
     }
-    
+
     func testValidReservedKeywordFor() throws {
         let fileName = "for.kt"
-        
+
         XCTAssertNoThrow(try KotlinFileNameValidator.validate(fileName))
     }
-    
+
     func testValidReservedKeywordWhile() throws {
         let fileName = "while.kt"
-        
+
         XCTAssertNoThrow(try KotlinFileNameValidator.validate(fileName))
     }
-    
+
     func testValidReservedKeywordReturn() throws {
         let fileName = "return.kt"
-        
+
         XCTAssertNoThrow(try KotlinFileNameValidator.validate(fileName))
     }
-    
+
     func testValidReservedKeywordTrue() throws {
         let fileName = "true.kt"
-        
+
         XCTAssertNoThrow(try KotlinFileNameValidator.validate(fileName))
     }
-    
+
     func testValidReservedKeywordFalse() throws {
         let fileName = "false.kt"
-        
+
         XCTAssertNoThrow(try KotlinFileNameValidator.validate(fileName))
     }
-    
+
     func testValidReservedKeywordNull() throws {
         let fileName = "null.kt"
-        
+
         XCTAssertNoThrow(try KotlinFileNameValidator.validate(fileName))
     }
-    
+
     func testValidReservedKeywordWhen() throws {
         let fileName = "when.kt"
-        
+
         XCTAssertNoThrow(try KotlinFileNameValidator.validate(fileName))
     }
-    
+
     func testValidReservedKeywordObject() throws {
         let fileName = "object.kt"
-        
+
         XCTAssertNoThrow(try KotlinFileNameValidator.validate(fileName))
     }
-    
+
     func testValidReservedKeywordCompanion() throws {
         let fileName = "companion.kt"
-        
+
         XCTAssertNoThrow(try KotlinFileNameValidator.validate(fileName))
     }
-    
+
     func testValidReservedKeywordSealed() throws {
         let fileName = "sealed.kt"
-        
+
         XCTAssertNoThrow(try KotlinFileNameValidator.validate(fileName))
     }
-    
+
     func testValidReservedKeywordAbstract() throws {
         let fileName = "abstract.kt"
-        
+
         XCTAssertNoThrow(try KotlinFileNameValidator.validate(fileName))
     }
-    
+
     func testValidReservedKeywordOpen() throws {
         let fileName = "open.kt"
-        
+
         XCTAssertNoThrow(try KotlinFileNameValidator.validate(fileName))
     }
-    
+
     func testValidReservedKeywordInternal() throws {
         let fileName = "internal.kt"
-        
+
         XCTAssertNoThrow(try KotlinFileNameValidator.validate(fileName))
     }
-    
+
     func testValidReservedKeywordPrivate() throws {
         let fileName = "private.kt"
-        
+
         XCTAssertNoThrow(try KotlinFileNameValidator.validate(fileName))
     }
-    
+
     func testValidReservedKeywordProtected() throws {
         let fileName = "protected.kt"
-        
+
         XCTAssertNoThrow(try KotlinFileNameValidator.validate(fileName))
     }
-    
+
     func testValidReservedKeywordPublic() throws {
         let fileName = "public.kt"
-        
+
         XCTAssertNoThrow(try KotlinFileNameValidator.validate(fileName))
     }
-    
+
     // MARK: - Edge Cases
-    
+
     func testVeryLongValidFileName() throws {
         let fileName = String(repeating: "A", count: 100) + ".kt"
-        
+
         XCTAssertNoThrow(try KotlinFileNameValidator.validate(fileName))
     }
-    
+
     func testFileNameWithOnlyUnderscores() throws {
         let fileName = "___"
-        
+
         XCTAssertThrowsError(try KotlinFileNameValidator.validate(fileName)) { error in
             XCTAssertTrue(error is KotlinFileNameValidationError)
             if case KotlinFileNameValidationError.missingKotlinExtension = error {
@@ -550,16 +549,16 @@ final class KotlinFileNameValidatorTests: XCTestCase {
             }
         }
     }
-    
+
     func testFileNameWithOnlyUnderscoresAndExtension() throws {
         let fileName = "___.kt"
-        
+
         XCTAssertNoThrow(try KotlinFileNameValidator.validate(fileName))
     }
-    
+
     func testFileNameWithOnlyDollarSigns() throws {
         let fileName = "$$$"
-        
+
         XCTAssertThrowsError(try KotlinFileNameValidator.validate(fileName)) { error in
             XCTAssertTrue(error is KotlinFileNameValidationError)
             if case KotlinFileNameValidationError.missingKotlinExtension = error {
@@ -569,28 +568,28 @@ final class KotlinFileNameValidatorTests: XCTestCase {
             }
         }
     }
-    
+
     func testFileNameWithOnlyDollarSignsAndExtension() throws {
         let fileName = "$$$.kt"
-        
+
         XCTAssertNoThrow(try KotlinFileNameValidator.validate(fileName))
     }
-    
+
     func testFileNameWithNumbersAndUnderscores() throws {
         let fileName = "Event_123_Test.kt"
-        
+
         XCTAssertNoThrow(try KotlinFileNameValidator.validate(fileName))
     }
-    
+
     func testFileNameWithNumbersAndDollarSigns() throws {
         let fileName = "Event$123$Test.kt"
-        
+
         XCTAssertNoThrow(try KotlinFileNameValidator.validate(fileName))
     }
-    
+
     func testFileNameWithMixedValidCharacters() throws {
         let fileName = "Event_123$Test_456.kt"
-        
+
         XCTAssertNoThrow(try KotlinFileNameValidator.validate(fileName))
     }
 }

--- a/Tests/EventPanelCLITests/KotlinGenGeneratorTests.swift
+++ b/Tests/EventPanelCLITests/KotlinGenGeneratorTests.swift
@@ -8,7 +8,7 @@ final class KotlinGenGeneratorTests: XCTestCase {
     func testGenerateAnalyticsEvents() throws {
         let config = KotlinGenPlugin.default
         let generator = KotlinGenGenerator(config: config)
-        
+
         let scheme = KotlinGenWorkspaceScheme(
             workspace: "test-workspace",
             events: [
@@ -49,17 +49,17 @@ final class KotlinGenGeneratorTests: XCTestCase {
                 .init(id: "user", name: "User", description: nil)
             ]
         )
-        
+
         let output = try generator.generate(scheme: scheme, stencilTemplate: stencilTemplate)
-        
+
         // Then
         assertSnapshot(of: output, as: .txt)
     }
-    
+
     func testGenerateAnalyticsEventsWithMultipleEvents() throws {
         let config = KotlinGenPlugin.default
         let generator = KotlinGenGenerator(config: config)
-        
+
         let scheme = KotlinGenWorkspaceScheme(
             workspace: "test-workspace",
             events: [
@@ -111,15 +111,15 @@ final class KotlinGenGeneratorTests: XCTestCase {
         )
 
         let output = try generator.generate(scheme: scheme, stencilTemplate: stencilTemplate)
-        
+
         // Then
         assertSnapshot(of: output, as: .txt)
     }
-    
+
     func testGenerateAnalyticsEventsWithComplexProperties() throws {
         let config = KotlinGenPlugin.default
         let generator = KotlinGenGenerator(config: config)
-        
+
         let scheme = KotlinGenWorkspaceScheme(
             workspace: "test-workspace",
             events: [
@@ -177,17 +177,17 @@ final class KotlinGenGeneratorTests: XCTestCase {
                 .init(id: "ecommerce", name: "E-commerce", description: nil)
             ]
         )
-        
+
         let output = try generator.generate(scheme: scheme, stencilTemplate: stencilTemplate)
-        
+
         // Then
         assertSnapshot(of: output, as: .txt)
     }
-    
+
     func testGenerateAnalyticsEventsWithCustomTypes() throws {
         let config = KotlinGenPlugin.default
         let generator = KotlinGenGenerator(config: config)
-        
+
         let scheme = KotlinGenWorkspaceScheme(
             workspace: "test-workspace",
             events: [
@@ -234,9 +234,9 @@ final class KotlinGenGeneratorTests: XCTestCase {
                 .init(id: "payment", name: "Payment", description: nil)
             ]
         )
-        
+
         let output = try generator.generate(scheme: scheme, stencilTemplate: stencilTemplate)
-        
+
         // Then
         assertSnapshot(of: output, as: .txt)
     }

--- a/Tests/EventPanelCLITests/KotlinGenGeneratorTests.swift
+++ b/Tests/EventPanelCLITests/KotlinGenGeneratorTests.swift
@@ -441,4 +441,52 @@ final class KotlinGenGeneratorTests: XCTestCase {
         // Then
         assertSnapshot(of: output, as: .txt)
     }
+
+    func testWithoutTypeDefinition() throws {
+        // Given
+        let config = KotlinGenPlugin(
+            outputFilePath: "GeneratedAnalyticsEvents.kt",
+            packageName: "com.analytics.events",
+            eventClassName: "AnalyticsEvent",
+            documentation: true,
+            shouldGenerateType: false
+        )
+        let generator = KotlinGenGenerator(config: config)
+
+        let scheme = KotlinGenWorkspaceScheme(
+            workspace: "test-workspace",
+            events: [
+                .init(
+                    id: "productView",
+                    name: "Product View",
+                    description: "User viewed a product",
+                    categoryIds: ["ecommerce"],
+                    properties: [
+                        .init(
+                            id: "product_id",
+                            name: "product_id",
+                            description: "Unique identifier of the product",
+                            dataType: .string,
+                            required: true,
+                            value: nil
+                        )
+                    ]
+                )
+            ],
+            customTypes: [],
+            categories: [
+                .init(
+                    id: "ecommerce",
+                    name: "E-commerce",
+                    description: "Screen represents a lot of products"
+                )
+            ]
+        )
+
+        // When
+        let output = try generator.generate(scheme: scheme, stencilTemplate: stencilTemplate)
+
+        // Then
+        assertSnapshot(of: output, as: .txt)
+    }
 }

--- a/Tests/EventPanelCLITests/KotlinGenGeneratorTests.swift
+++ b/Tests/EventPanelCLITests/KotlinGenGeneratorTests.swift
@@ -6,7 +6,6 @@ final class KotlinGenGeneratorTests: XCTestCase {
     let stencilTemplate = try! KotlinGenStencilTemplate.default()
 
     func testGenerateAnalyticsEvents() throws {
-        // Given
         let config = KotlinGenPlugin.default
         let generator = KotlinGenGenerator(config: config)
         
@@ -51,7 +50,6 @@ final class KotlinGenGeneratorTests: XCTestCase {
             ]
         )
         
-        // When
         let output = try generator.generate(scheme: scheme, stencilTemplate: stencilTemplate)
         
         // Then
@@ -59,7 +57,6 @@ final class KotlinGenGeneratorTests: XCTestCase {
     }
     
     func testGenerateAnalyticsEventsWithMultipleEvents() throws {
-        // Given
         let config = KotlinGenPlugin.default
         let generator = KotlinGenGenerator(config: config)
         
@@ -113,7 +110,6 @@ final class KotlinGenGeneratorTests: XCTestCase {
             ]
         )
 
-        // When
         let output = try generator.generate(scheme: scheme, stencilTemplate: stencilTemplate)
         
         // Then
@@ -121,7 +117,6 @@ final class KotlinGenGeneratorTests: XCTestCase {
     }
     
     func testGenerateAnalyticsEventsWithComplexProperties() throws {
-        // Given
         let config = KotlinGenPlugin.default
         let generator = KotlinGenGenerator(config: config)
         
@@ -183,7 +178,6 @@ final class KotlinGenGeneratorTests: XCTestCase {
             ]
         )
         
-        // When
         let output = try generator.generate(scheme: scheme, stencilTemplate: stencilTemplate)
         
         // Then
@@ -191,7 +185,6 @@ final class KotlinGenGeneratorTests: XCTestCase {
     }
     
     func testGenerateAnalyticsEventsWithCustomTypes() throws {
-        // Given
         let config = KotlinGenPlugin.default
         let generator = KotlinGenGenerator(config: config)
         
@@ -242,7 +235,6 @@ final class KotlinGenGeneratorTests: XCTestCase {
             ]
         )
         
-        // When
         let output = try generator.generate(scheme: scheme, stencilTemplate: stencilTemplate)
         
         // Then
@@ -250,7 +242,6 @@ final class KotlinGenGeneratorTests: XCTestCase {
     }
 
     func testUncategorisedEvents() throws {
-        // Given
         let config = KotlinGenPlugin.default
         let generator = KotlinGenGenerator(config: config)
 
@@ -286,7 +277,6 @@ final class KotlinGenGeneratorTests: XCTestCase {
             categories: nil
         )
 
-        // When
         let output = try generator.generate(scheme: scheme, stencilTemplate: stencilTemplate)
 
         // Then
@@ -294,7 +284,6 @@ final class KotlinGenGeneratorTests: XCTestCase {
     }
 
     func testEventWithEmptyDescription() throws {
-        // Given
         let config = KotlinGenPlugin.default
         let generator = KotlinGenGenerator(config: config)
 
@@ -330,7 +319,6 @@ final class KotlinGenGeneratorTests: XCTestCase {
             categories: []
         )
 
-        // When
         let output = try generator.generate(scheme: scheme, stencilTemplate: stencilTemplate)
 
         // Then
@@ -338,7 +326,6 @@ final class KotlinGenGeneratorTests: XCTestCase {
     }
 
     func testEventWithEmptyProperties() throws {
-        // Given
         let config = KotlinGenPlugin.default
         let generator = KotlinGenGenerator(config: config)
 
@@ -357,7 +344,6 @@ final class KotlinGenGeneratorTests: XCTestCase {
             categories: []
         )
 
-        // When
         let output = try generator.generate(scheme: scheme, stencilTemplate: stencilTemplate)
 
         // Then
@@ -365,7 +351,6 @@ final class KotlinGenGeneratorTests: XCTestCase {
     }
 
     func testEventWithPropertyWithEmptyDescription() throws {
-        // Given
         let config = KotlinGenPlugin.default
         let generator = KotlinGenGenerator(config: config)
 
@@ -393,7 +378,6 @@ final class KotlinGenGeneratorTests: XCTestCase {
             categories: []
         )
 
-        // When
         let output = try generator.generate(scheme: scheme, stencilTemplate: stencilTemplate)
 
         // Then
@@ -401,7 +385,6 @@ final class KotlinGenGeneratorTests: XCTestCase {
     }
 
     func testCategoryDescription() throws {
-        // Given
         let config = KotlinGenPlugin.default
         let generator = KotlinGenGenerator(config: config)
 
@@ -435,7 +418,6 @@ final class KotlinGenGeneratorTests: XCTestCase {
             ]
         )
 
-        // When
         let output = try generator.generate(scheme: scheme, stencilTemplate: stencilTemplate)
 
         // Then
@@ -443,7 +425,6 @@ final class KotlinGenGeneratorTests: XCTestCase {
     }
 
     func testWithoutTypeDefinition() throws {
-        // Given
         let config = KotlinGenPlugin(
             outputFilePath: "GeneratedAnalyticsEvents.kt",
             packageName: "com.analytics.events",
@@ -483,7 +464,6 @@ final class KotlinGenGeneratorTests: XCTestCase {
             ]
         )
 
-        // When
         let output = try generator.generate(scheme: scheme, stencilTemplate: stencilTemplate)
 
         // Then

--- a/Tests/EventPanelCLITests/OutputPathValidatorTests.swift
+++ b/Tests/EventPanelCLITests/OutputPathValidatorTests.swift
@@ -27,11 +27,9 @@ final class OutputPathValidatorTests: XCTestCase {
     // MARK: - Valid Path Tests
     
     func testValidPath() throws {
-        // Given
         let outputPath = "Events.swift"
         let source = Source.iOS
         
-        // When
         let result = try validator.validate(outputPath, for: source, workingDirectory: tempDirectory)
         
         // Then
@@ -39,11 +37,9 @@ final class OutputPathValidatorTests: XCTestCase {
     }
     
     func testValidNestedPath() throws {
-        // Given
         let outputPath = "Analytics/Events.swift"
         let source = Source.iOS
         
-        // When
         let result = try validator.validate(outputPath, for: source, workingDirectory: tempDirectory)
         
         // Then
@@ -51,11 +47,9 @@ final class OutputPathValidatorTests: XCTestCase {
     }
     
     func testValidDeeplyNestedPath() throws {
-        // Given
         let outputPath = "Features/Analytics/Events/EventTracker.swift"
         let source = Source.iOS
         
-        // When
         let result = try validator.validate(outputPath, for: source, workingDirectory: tempDirectory)
         
         // Then
@@ -63,11 +57,9 @@ final class OutputPathValidatorTests: XCTestCase {
     }
     
     func testValidKotlinPath() throws {
-        // Given
         let outputPath = "Analytics/Events.kt"
         let source = Source.android
         
-        // When
         let result = try validator.validate(outputPath, for: source, workingDirectory: tempDirectory)
         
         // Then
@@ -77,68 +69,54 @@ final class OutputPathValidatorTests: XCTestCase {
     // MARK: - Directory Traversal Attack Tests
     
     func testDirectoryTraversalWithDoubleDots() {
-        // Given
         let outputPath = "../../../etc/passwd"
         let source = Source.iOS
         
-        // When & Then
         XCTAssertThrowsError(try validator.validate(outputPath, for: source, workingDirectory: tempDirectory))
     }
     
     func testDirectoryTraversalWithMultipleDoubleDots() {
-        // Given
         let outputPath = "Analytics/../../../etc/passwd"
         let source = Source.iOS
         
-        // When & Then
         XCTAssertThrowsError(try validator.validate(outputPath, for: source, workingDirectory: tempDirectory))
     }
     
     func testDirectoryTraversalWithAbsolutePath() {
-        // Given
         let outputPath = "/etc/passwd"
         let source = Source.iOS
         
-        // When & Then
         XCTAssertThrowsError(try validator.validate(outputPath, for: source, workingDirectory: tempDirectory))
     }
     
     func testDirectoryTraversalWithDoubleSlash() {
-        // Given
         let outputPath = "Analytics//../../../etc/passwd"
         let source = Source.iOS
         
-        // When & Then
         XCTAssertThrowsError(try validator.validate(outputPath, for: source, workingDirectory: tempDirectory))
     }
     
     func testDirectoryTraversalWithEncodedDoubleDots() {
-        // Given
         let outputPath = "Analytics%2F..%2F..%2F..%2Fetc%2Fpasswd"
         let source = Source.iOS
         
-        // When & Then
         // This should fail the basic .. check
         XCTAssertThrowsError(try validator.validate(outputPath, for: source, workingDirectory: tempDirectory))
     }
     
     func testDirectoryTraversalWithMixedSeparators() {
-        // Given
         let outputPath = "Analytics\\..\\..\\..\\etc\\passwd"
         let source = Source.iOS
         
-        // When & Then
         XCTAssertThrowsError(try validator.validate(outputPath, for: source, workingDirectory: tempDirectory))
     }
     
     // MARK: - Edge Cases
     
     func testEmptyPath() {
-        // Given
         let outputPath = ""
         let source = Source.iOS
         
-        // When & Then
         XCTAssertThrowsError(try validator.validate(outputPath, for: source, workingDirectory: tempDirectory)) { error in
             XCTAssertTrue(error is OutputPathValidationError)
             if case OutputPathValidationError.emptyOutputPath = error {
@@ -150,11 +128,9 @@ final class OutputPathValidatorTests: XCTestCase {
     }
     
     func testWhitespaceOnlyPath() {
-        // Given
         let outputPath = "   "
         let source = Source.iOS
         
-        // When & Then
         XCTAssertThrowsError(try validator.validate(outputPath, for: source, workingDirectory: tempDirectory)) { error in
             XCTAssertTrue(error is OutputPathValidationError)
             if case OutputPathValidationError.emptyOutputPath = error {
@@ -166,11 +142,9 @@ final class OutputPathValidatorTests: XCTestCase {
     }
     
     func testPathWithWhitespace() throws {
-        // Given
         let outputPath = "  Events.swift  "
         let source = Source.iOS
         
-        // When
         let result = try validator.validate(outputPath, for: source, workingDirectory: tempDirectory)
         
         // Then
@@ -180,7 +154,6 @@ final class OutputPathValidatorTests: XCTestCase {
     // MARK: - Symlink Tests
     
     func testPathWithSymlink() throws {
-        // Given
         let symlinkTarget = tempDirectory.appendingPathComponent("target")
         let symlink = tempDirectory.appendingPathComponent("symlink")
         
@@ -193,7 +166,6 @@ final class OutputPathValidatorTests: XCTestCase {
         let outputPath = "symlink/Events.swift"
         let source = Source.iOS
         
-        // When
         let result = try validator.validate(outputPath, for: source, workingDirectory: tempDirectory)
         
         // Then
@@ -201,7 +173,6 @@ final class OutputPathValidatorTests: XCTestCase {
     }
     
     func testDirectoryTraversalThroughSymlink() {
-        // Given
         let parentDirectory = tempDirectory.deletingLastPathComponent()
         let symlink = tempDirectory.appendingPathComponent("parent")
         
@@ -211,29 +182,24 @@ final class OutputPathValidatorTests: XCTestCase {
         let outputPath = "parent/../../../etc/passwd"
         let source = Source.iOS
         
-        // When & Then
         XCTAssertThrowsError(try validator.validate(outputPath, for: source, workingDirectory: tempDirectory))
     }
     
     // MARK: - File Name Validation Tests
     
     func testInvalidFileName() {
-        // Given
         let outputPath = "Events.txt" // Wrong extension for iOS
         let source = Source.iOS
         
-        // When & Then
         XCTAssertThrowsError(try validator.validate(outputPath, for: source, workingDirectory: tempDirectory)) { error in
             XCTAssertTrue(error is SwiftFileNameValidationError)
         }
     }
     
     func testValidFileNameWithSpecialCharacters() throws {
-        // Given
         let outputPath = "Events+File.swift"
         let source = Source.iOS
         
-        // When
         let result = try validator.validate(outputPath, for: source, workingDirectory: tempDirectory)
         
         // Then
@@ -243,11 +209,9 @@ final class OutputPathValidatorTests: XCTestCase {
     // MARK: - Path Normalization Tests
     
     func testPathWithSingleDots() throws {
-        // Given
         let outputPath = "./Analytics/./Events.swift"
         let source = Source.iOS
         
-        // When
         let result = try validator.validate(outputPath, for: source, workingDirectory: tempDirectory)
         
         // Then
@@ -255,11 +219,9 @@ final class OutputPathValidatorTests: XCTestCase {
     }
     
     func testPathWithTrailingSlash() throws {
-        // Given
         let outputPath = "Analytics/Events.swift/"
         let source = Source.iOS
         
-        // When
         let result = try validator.validate(outputPath, for: source, workingDirectory: tempDirectory)
         
         // Then

--- a/Tests/EventPanelCLITests/OutputPathValidatorTests.swift
+++ b/Tests/EventPanelCLITests/OutputPathValidatorTests.swift
@@ -2,121 +2,121 @@ import XCTest
 @testable import eventpanel
 
 final class OutputPathValidatorTests: XCTestCase {
-    
+
     private var validator: DefaultOutputPathValidator!
     private var tempDirectory: URL!
-    
+
     override func setUp() {
         super.setUp()
         validator = DefaultOutputPathValidator()
-        
+
         // Create a temporary directory for testing
         tempDirectory = FileManager.default.temporaryDirectory
             .appendingPathComponent("OutputPathValidatorTests")
             .appendingPathComponent(UUID().uuidString)
-        
+
         try? FileManager.default.createDirectory(at: tempDirectory, withIntermediateDirectories: true)
     }
-    
+
     override func tearDown() {
         // Clean up the temporary directory
         try? FileManager.default.removeItem(at: tempDirectory)
         super.tearDown()
     }
-    
+
     // MARK: - Valid Path Tests
-    
+
     func testValidPath() throws {
         let outputPath = "Events.swift"
         let source = Source.iOS
-        
+
         let result = try validator.validate(outputPath, for: source, workingDirectory: tempDirectory)
-        
+
         // Then
         XCTAssertEqual(result, "Events.swift")
     }
-    
+
     func testValidNestedPath() throws {
         let outputPath = "Analytics/Events.swift"
         let source = Source.iOS
-        
+
         let result = try validator.validate(outputPath, for: source, workingDirectory: tempDirectory)
-        
+
         // Then
         XCTAssertEqual(result, "Analytics/Events.swift")
     }
-    
+
     func testValidDeeplyNestedPath() throws {
         let outputPath = "Features/Analytics/Events/EventTracker.swift"
         let source = Source.iOS
-        
+
         let result = try validator.validate(outputPath, for: source, workingDirectory: tempDirectory)
-        
+
         // Then
         XCTAssertEqual(result, "Features/Analytics/Events/EventTracker.swift")
     }
-    
+
     func testValidKotlinPath() throws {
         let outputPath = "Analytics/Events.kt"
         let source = Source.android
-        
+
         let result = try validator.validate(outputPath, for: source, workingDirectory: tempDirectory)
-        
+
         // Then
         XCTAssertEqual(result, "Analytics/Events.kt")
     }
-    
+
     // MARK: - Directory Traversal Attack Tests
-    
+
     func testDirectoryTraversalWithDoubleDots() {
         let outputPath = "../../../etc/passwd"
         let source = Source.iOS
-        
+
         XCTAssertThrowsError(try validator.validate(outputPath, for: source, workingDirectory: tempDirectory))
     }
-    
+
     func testDirectoryTraversalWithMultipleDoubleDots() {
         let outputPath = "Analytics/../../../etc/passwd"
         let source = Source.iOS
-        
+
         XCTAssertThrowsError(try validator.validate(outputPath, for: source, workingDirectory: tempDirectory))
     }
-    
+
     func testDirectoryTraversalWithAbsolutePath() {
         let outputPath = "/etc/passwd"
         let source = Source.iOS
-        
+
         XCTAssertThrowsError(try validator.validate(outputPath, for: source, workingDirectory: tempDirectory))
     }
-    
+
     func testDirectoryTraversalWithDoubleSlash() {
         let outputPath = "Analytics//../../../etc/passwd"
         let source = Source.iOS
-        
+
         XCTAssertThrowsError(try validator.validate(outputPath, for: source, workingDirectory: tempDirectory))
     }
-    
+
     func testDirectoryTraversalWithEncodedDoubleDots() {
         let outputPath = "Analytics%2F..%2F..%2F..%2Fetc%2Fpasswd"
         let source = Source.iOS
-        
+
         // This should fail the basic .. check
         XCTAssertThrowsError(try validator.validate(outputPath, for: source, workingDirectory: tempDirectory))
     }
-    
+
     func testDirectoryTraversalWithMixedSeparators() {
         let outputPath = "Analytics\\..\\..\\..\\etc\\passwd"
         let source = Source.iOS
-        
+
         XCTAssertThrowsError(try validator.validate(outputPath, for: source, workingDirectory: tempDirectory))
     }
-    
+
     // MARK: - Edge Cases
-    
+
     func testEmptyPath() {
         let outputPath = ""
         let source = Source.iOS
-        
+
         XCTAssertThrowsError(try validator.validate(outputPath, for: source, workingDirectory: tempDirectory)) { error in
             XCTAssertTrue(error is OutputPathValidationError)
             if case OutputPathValidationError.emptyOutputPath = error {
@@ -126,11 +126,11 @@ final class OutputPathValidatorTests: XCTestCase {
             }
         }
     }
-    
+
     func testWhitespaceOnlyPath() {
         let outputPath = "   "
         let source = Source.iOS
-        
+
         XCTAssertThrowsError(try validator.validate(outputPath, for: source, workingDirectory: tempDirectory)) { error in
             XCTAssertTrue(error is OutputPathValidationError)
             if case OutputPathValidationError.emptyOutputPath = error {
@@ -140,90 +140,90 @@ final class OutputPathValidatorTests: XCTestCase {
             }
         }
     }
-    
+
     func testPathWithWhitespace() throws {
         let outputPath = "  Events.swift  "
         let source = Source.iOS
-        
+
         let result = try validator.validate(outputPath, for: source, workingDirectory: tempDirectory)
-        
+
         // Then
         XCTAssertEqual(result, "Events.swift")
     }
-    
+
     // MARK: - Symlink Tests
-    
+
     func testPathWithSymlink() throws {
         let symlinkTarget = tempDirectory.appendingPathComponent("target")
         let symlink = tempDirectory.appendingPathComponent("symlink")
-        
+
         // Create a target directory
         try FileManager.default.createDirectory(at: symlinkTarget, withIntermediateDirectories: true)
-        
+
         // Create a symlink
         try FileManager.default.createSymbolicLink(at: symlink, withDestinationURL: symlinkTarget)
-        
+
         let outputPath = "symlink/Events.swift"
         let source = Source.iOS
-        
+
         let result = try validator.validate(outputPath, for: source, workingDirectory: tempDirectory)
-        
+
         // Then
         XCTAssertEqual(result, "symlink/Events.swift")
     }
-    
+
     func testDirectoryTraversalThroughSymlink() {
         let parentDirectory = tempDirectory.deletingLastPathComponent()
         let symlink = tempDirectory.appendingPathComponent("parent")
-        
+
         // Create a symlink pointing to parent directory
         try? FileManager.default.createSymbolicLink(at: symlink, withDestinationURL: parentDirectory)
-        
+
         let outputPath = "parent/../../../etc/passwd"
         let source = Source.iOS
-        
+
         XCTAssertThrowsError(try validator.validate(outputPath, for: source, workingDirectory: tempDirectory))
     }
-    
+
     // MARK: - File Name Validation Tests
-    
+
     func testInvalidFileName() {
         let outputPath = "Events.txt" // Wrong extension for iOS
         let source = Source.iOS
-        
+
         XCTAssertThrowsError(try validator.validate(outputPath, for: source, workingDirectory: tempDirectory)) { error in
             XCTAssertTrue(error is SwiftFileNameValidationError)
         }
     }
-    
+
     func testValidFileNameWithSpecialCharacters() throws {
         let outputPath = "Events+File.swift"
         let source = Source.iOS
-        
+
         let result = try validator.validate(outputPath, for: source, workingDirectory: tempDirectory)
-        
+
         // Then
         XCTAssertEqual(result, "Events+File.swift")
     }
-    
+
     // MARK: - Path Normalization Tests
-    
+
     func testPathWithSingleDots() throws {
         let outputPath = "./Analytics/./Events.swift"
         let source = Source.iOS
-        
+
         let result = try validator.validate(outputPath, for: source, workingDirectory: tempDirectory)
-        
+
         // Then
         XCTAssertEqual(result, "./Analytics/./Events.swift")
     }
-    
+
     func testPathWithTrailingSlash() throws {
         let outputPath = "Analytics/Events.swift/"
         let source = Source.iOS
-        
+
         let result = try validator.validate(outputPath, for: source, workingDirectory: tempDirectory)
-        
+
         // Then
         // URL.appendingPathComponent normalizes trailing slashes, so this should work
         XCTAssertEqual(result, "Analytics/Events.swift/")

--- a/Tests/EventPanelCLITests/SwiftFileNameValidatorTests.swift
+++ b/Tests/EventPanelCLITests/SwiftFileNameValidatorTests.swift
@@ -6,52 +6,40 @@ final class SwiftFileNameValidatorTests: XCTestCase {
     // MARK: - Valid File Names
     
     func testValidFileName() throws {
-        // Given
         let fileName = "Events.swift"
         
-        // When & Then
         XCTAssertNoThrow(try SwiftFileNameValidator.validate(fileName))
     }
     
     func testValidFileNameWithUnderscore() throws {
-        // Given
         let fileName = "Analytics_Events.swift"
         
-        // When & Then
         XCTAssertNoThrow(try SwiftFileNameValidator.validate(fileName))
     }
     
     func testValidFileNameWithNumbers() throws {
-        // Given
         let fileName = "Event2.swift"
         
-        // When & Then
         XCTAssertNoThrow(try SwiftFileNameValidator.validate(fileName))
     }
     
     func testValidFileNameStartingWithUnderscore() throws {
-        // Given
         let fileName = "_PrivateEvents.swift"
         
-        // When & Then
         XCTAssertNoThrow(try SwiftFileNameValidator.validate(fileName))
     }
     
     func testValidFileNameWithWhitespace() throws {
-        // Given
         let fileName = "  Events.swift  "
         
-        // When & Then
         XCTAssertNoThrow(try SwiftFileNameValidator.validate(fileName))
     }
     
     // MARK: - Empty File Name Tests
     
     func testEmptyFileName() {
-        // Given
         let fileName = ""
         
-        // When & Then
         XCTAssertThrowsError(try SwiftFileNameValidator.validate(fileName)) { error in
             XCTAssertTrue(error is SwiftFileNameValidationError)
             if case SwiftFileNameValidationError.emptyFileName = error {
@@ -63,10 +51,8 @@ final class SwiftFileNameValidatorTests: XCTestCase {
     }
     
     func testWhitespaceOnlyFileName() {
-        // Given
         let fileName = "   "
         
-        // When & Then
         XCTAssertThrowsError(try SwiftFileNameValidator.validate(fileName)) { error in
             XCTAssertTrue(error is SwiftFileNameValidationError)
             if case SwiftFileNameValidationError.emptyFileName = error {
@@ -78,10 +64,8 @@ final class SwiftFileNameValidatorTests: XCTestCase {
     }
     
     func testNewlineOnlyFileName() {
-        // Given
         let fileName = "\n\t"
         
-        // When & Then
         XCTAssertThrowsError(try SwiftFileNameValidator.validate(fileName)) { error in
             XCTAssertTrue(error is SwiftFileNameValidationError)
             if case SwiftFileNameValidationError.emptyFileName = error {
@@ -95,10 +79,8 @@ final class SwiftFileNameValidatorTests: XCTestCase {
     // MARK: - Missing Extension Tests
     
     func testMissingSwiftExtension() {
-        // Given
         let fileName = "Events"
         
-        // When & Then
         XCTAssertThrowsError(try SwiftFileNameValidator.validate(fileName)) { error in
             XCTAssertTrue(error is SwiftFileNameValidationError)
             if case SwiftFileNameValidationError.missingSwiftExtension = error {
@@ -110,10 +92,8 @@ final class SwiftFileNameValidatorTests: XCTestCase {
     }
     
     func testWrongExtension() {
-        // Given
         let fileName = "Events.txt"
         
-        // When & Then
         XCTAssertThrowsError(try SwiftFileNameValidator.validate(fileName)) { error in
             XCTAssertTrue(error is SwiftFileNameValidationError)
             if case SwiftFileNameValidationError.missingSwiftExtension = error {
@@ -125,10 +105,8 @@ final class SwiftFileNameValidatorTests: XCTestCase {
     }
     
     func testCaseSensitiveExtension() {
-        // Given
         let fileName = "Events.SWIFT"
         
-        // When & Then
         XCTAssertThrowsError(try SwiftFileNameValidator.validate(fileName)) { error in
             XCTAssertTrue(error is SwiftFileNameValidationError)
             if case SwiftFileNameValidationError.missingSwiftExtension = error {
@@ -142,10 +120,8 @@ final class SwiftFileNameValidatorTests: XCTestCase {
     // MARK: - Empty Base Name Tests
     
     func testEmptyBaseName() {
-        // Given
         let fileName = ".swift"
         
-        // When & Then
         XCTAssertThrowsError(try SwiftFileNameValidator.validate(fileName)) { error in
             XCTAssertTrue(error is SwiftFileNameValidationError)
             if case SwiftFileNameValidationError.emptyBaseName = error {
@@ -157,10 +133,8 @@ final class SwiftFileNameValidatorTests: XCTestCase {
     }
     
     func testWhitespaceBaseName() {
-        // Given
         let fileName = "   .swift"
         
-        // When & Then
         XCTAssertThrowsError(try SwiftFileNameValidator.validate(fileName)) { error in
             XCTAssertTrue(error is SwiftFileNameValidationError)
             if case SwiftFileNameValidationError.emptyBaseName = error {
@@ -174,10 +148,8 @@ final class SwiftFileNameValidatorTests: XCTestCase {
     // MARK: - Invalid Start Character Tests
     
     func testInvalidStartCharacterNumber() {
-        // Given
         let fileName = "2Events.swift"
         
-        // When & Then
         XCTAssertThrowsError(try SwiftFileNameValidator.validate(fileName)) { error in
             XCTAssertTrue(error is SwiftFileNameValidationError)
             if case SwiftFileNameValidationError.invalidStartCharacter = error {
@@ -189,10 +161,8 @@ final class SwiftFileNameValidatorTests: XCTestCase {
     }
     
     func testInvalidStartCharacterSpecialChar() {
-        // Given
         let fileName = "@Events.swift"
         
-        // When & Then
         XCTAssertThrowsError(try SwiftFileNameValidator.validate(fileName)) { error in
             XCTAssertTrue(error is SwiftFileNameValidationError)
             if case SwiftFileNameValidationError.invalidStartCharacter = error {
@@ -204,10 +174,8 @@ final class SwiftFileNameValidatorTests: XCTestCase {
     }
     
     func testInvalidStartCharacterDollarSign() {
-        // Given
         let fileName = "$Events.swift"
         
-        // When & Then
         XCTAssertThrowsError(try SwiftFileNameValidator.validate(fileName)) { error in
             XCTAssertTrue(error is SwiftFileNameValidationError)
             if case SwiftFileNameValidationError.invalidStartCharacter = error {
@@ -221,83 +189,63 @@ final class SwiftFileNameValidatorTests: XCTestCase {
     // MARK: - Invalid Characters Tests
     
     func testValidFileNameWithHyphen() throws {
-        // Given
         let fileName = "Events-File.swift"
         
-        // When & Then
         XCTAssertNoThrow(try SwiftFileNameValidator.validate(fileName))
     }
     
     func testValidFileNameWithPeriod() throws {
-        // Given
         let fileName = "Events.File.swift"
         
-        // When & Then
         XCTAssertNoThrow(try SwiftFileNameValidator.validate(fileName))
     }
     
     func testValidFileNameWithMultiplePeriods() throws {
-        // Given
         let fileName = "Events.File.Utils.swift"
         
-        // When & Then
         XCTAssertNoThrow(try SwiftFileNameValidator.validate(fileName))
     }
     
     func testValidFileNameWithPlus() throws {
-        // Given
         let fileName = "Events+File.swift"
         
-        // When & Then
         XCTAssertNoThrow(try SwiftFileNameValidator.validate(fileName))
     }
     
     func testValidFileNameWithSpace() throws {
-        // Given
         let fileName = "Events File.swift"
         
-        // When & Then
         XCTAssertNoThrow(try SwiftFileNameValidator.validate(fileName))
     }
     
     func testValidFileNameWithAtSign() throws {
-        // Given
         let fileName = "Events@File.swift"
         
-        // When & Then
         XCTAssertNoThrow(try SwiftFileNameValidator.validate(fileName))
     }
     
     func testValidFileNameWithHash() throws {
-        // Given
         let fileName = "Events#File.swift"
         
-        // When & Then
         XCTAssertNoThrow(try SwiftFileNameValidator.validate(fileName))
     }
     
     func testValidFileNameWithPercent() throws {
-        // Given
         let fileName = "Events%File.swift"
         
-        // When & Then
         XCTAssertNoThrow(try SwiftFileNameValidator.validate(fileName))
     }
     
     func testValidFileNameWithExclamation() throws {
-        // Given
         let fileName = "Events!File.swift"
         
-        // When & Then
         XCTAssertNoThrow(try SwiftFileNameValidator.validate(fileName))
     }
     
     
     func testInvalidCharactersColon() {
-        // Given
         let fileName = "Events:File.swift"
         
-        // When & Then
         XCTAssertThrowsError(try SwiftFileNameValidator.validate(fileName)) { error in
             XCTAssertTrue(error is SwiftFileNameValidationError)
             if case SwiftFileNameValidationError.invalidCharacters = error {
@@ -309,10 +257,8 @@ final class SwiftFileNameValidatorTests: XCTestCase {
     }
     
     func testInvalidCharactersSlash() {
-        // Given
         let fileName = "Events/File.swift"
         
-        // When & Then
         XCTAssertThrowsError(try SwiftFileNameValidator.validate(fileName)) { error in
             XCTAssertTrue(error is SwiftFileNameValidationError)
             if case SwiftFileNameValidationError.invalidCharacters = error {
@@ -324,10 +270,8 @@ final class SwiftFileNameValidatorTests: XCTestCase {
     }
     
     func testInvalidCharactersBackslash() {
-        // Given
         let fileName = "Events\\File.swift"
         
-        // When & Then
         XCTAssertThrowsError(try SwiftFileNameValidator.validate(fileName)) { error in
             XCTAssertTrue(error is SwiftFileNameValidationError)
             if case SwiftFileNameValidationError.invalidCharacters = error {
@@ -339,10 +283,8 @@ final class SwiftFileNameValidatorTests: XCTestCase {
     }
     
     func testInvalidCharactersQuestionMark() {
-        // Given
         let fileName = "Events?File.swift"
         
-        // When & Then
         XCTAssertThrowsError(try SwiftFileNameValidator.validate(fileName)) { error in
             XCTAssertTrue(error is SwiftFileNameValidationError)
             if case SwiftFileNameValidationError.invalidCharacters = error {
@@ -354,10 +296,8 @@ final class SwiftFileNameValidatorTests: XCTestCase {
     }
     
     func testInvalidCharactersAsterisk() {
-        // Given
         let fileName = "Events*File.swift"
         
-        // When & Then
         XCTAssertThrowsError(try SwiftFileNameValidator.validate(fileName)) { error in
             XCTAssertTrue(error is SwiftFileNameValidationError)
             if case SwiftFileNameValidationError.invalidCharacters = error {
@@ -369,10 +309,8 @@ final class SwiftFileNameValidatorTests: XCTestCase {
     }
     
     func testInvalidCharactersQuote() {
-        // Given
         let fileName = "Events\"File.swift"
         
-        // When & Then
         XCTAssertThrowsError(try SwiftFileNameValidator.validate(fileName)) { error in
             XCTAssertTrue(error is SwiftFileNameValidationError)
             if case SwiftFileNameValidationError.invalidCharacters = error {
@@ -384,10 +322,8 @@ final class SwiftFileNameValidatorTests: XCTestCase {
     }
     
     func testInvalidCharactersLessThan() {
-        // Given
         let fileName = "Events<File.swift"
         
-        // When & Then
         XCTAssertThrowsError(try SwiftFileNameValidator.validate(fileName)) { error in
             XCTAssertTrue(error is SwiftFileNameValidationError)
             if case SwiftFileNameValidationError.invalidCharacters = error {
@@ -399,10 +335,8 @@ final class SwiftFileNameValidatorTests: XCTestCase {
     }
     
     func testInvalidCharactersGreaterThan() {
-        // Given
         let fileName = "Events>File.swift"
         
-        // When & Then
         XCTAssertThrowsError(try SwiftFileNameValidator.validate(fileName)) { error in
             XCTAssertTrue(error is SwiftFileNameValidationError)
             if case SwiftFileNameValidationError.invalidCharacters = error {
@@ -414,10 +348,8 @@ final class SwiftFileNameValidatorTests: XCTestCase {
     }
     
     func testInvalidCharactersPipe() {
-        // Given
         let fileName = "Events|File.swift"
         
-        // When & Then
         XCTAssertThrowsError(try SwiftFileNameValidator.validate(fileName)) { error in
             XCTAssertTrue(error is SwiftFileNameValidationError)
             if case SwiftFileNameValidationError.invalidCharacters = error {
@@ -431,140 +363,106 @@ final class SwiftFileNameValidatorTests: XCTestCase {
     // MARK: - Valid Reserved Keyword File Names (These should now be valid)
     
     func testValidReservedKeywordClass() throws {
-        // Given
         let fileName = "class.swift"
         
-        // When & Then
         XCTAssertNoThrow(try SwiftFileNameValidator.validate(fileName))
     }
     
     func testValidReservedKeywordFunc() throws {
-        // Given
         let fileName = "func.swift"
         
-        // When & Then
         XCTAssertNoThrow(try SwiftFileNameValidator.validate(fileName))
     }
     
     func testValidReservedKeywordStruct() throws {
-        // Given
         let fileName = "struct.swift"
         
-        // When & Then
         XCTAssertNoThrow(try SwiftFileNameValidator.validate(fileName))
     }
     
     func testValidReservedKeywordEnum() throws {
-        // Given
         let fileName = "enum.swift"
         
-        // When & Then
         XCTAssertNoThrow(try SwiftFileNameValidator.validate(fileName))
     }
     
     func testValidReservedKeywordProtocol() throws {
-        // Given
         let fileName = "protocol.swift"
         
-        // When & Then
         XCTAssertNoThrow(try SwiftFileNameValidator.validate(fileName))
     }
     
     func testValidReservedKeywordImport() throws {
-        // Given
         let fileName = "import.swift"
         
-        // When & Then
         XCTAssertNoThrow(try SwiftFileNameValidator.validate(fileName))
     }
     
     func testValidReservedKeywordVar() throws {
-        // Given
         let fileName = "var.swift"
         
-        // When & Then
         XCTAssertNoThrow(try SwiftFileNameValidator.validate(fileName))
     }
     
     func testValidReservedKeywordLet() throws {
-        // Given
         let fileName = "let.swift"
         
-        // When & Then
         XCTAssertNoThrow(try SwiftFileNameValidator.validate(fileName))
     }
     
     func testValidReservedKeywordIf() throws {
-        // Given
         let fileName = "if.swift"
         
-        // When & Then
         XCTAssertNoThrow(try SwiftFileNameValidator.validate(fileName))
     }
     
     func testValidReservedKeywordFor() throws {
-        // Given
         let fileName = "for.swift"
         
-        // When & Then
         XCTAssertNoThrow(try SwiftFileNameValidator.validate(fileName))
     }
     
     func testValidReservedKeywordWhile() throws {
-        // Given
         let fileName = "while.swift"
         
-        // When & Then
         XCTAssertNoThrow(try SwiftFileNameValidator.validate(fileName))
     }
     
     func testValidReservedKeywordReturn() throws {
-        // Given
         let fileName = "return.swift"
         
-        // When & Then
         XCTAssertNoThrow(try SwiftFileNameValidator.validate(fileName))
     }
     
     func testValidReservedKeywordTrue() throws {
-        // Given
         let fileName = "true.swift"
         
-        // When & Then
         XCTAssertNoThrow(try SwiftFileNameValidator.validate(fileName))
     }
     
     func testValidReservedKeywordFalse() throws {
-        // Given
         let fileName = "false.swift"
         
-        // When & Then
         XCTAssertNoThrow(try SwiftFileNameValidator.validate(fileName))
     }
     
     func testValidReservedKeywordNil() throws {
-        // Given
         let fileName = "nil.swift"
         
-        // When & Then
         XCTAssertNoThrow(try SwiftFileNameValidator.validate(fileName))
     }
     
     // MARK: - Edge Cases
     
     func testVeryLongValidFileName() throws {
-        // Given
         let fileName = String(repeating: "A", count: 100) + ".swift"
         
-        // When & Then
         XCTAssertNoThrow(try SwiftFileNameValidator.validate(fileName))
     }
     
     func testFileNameWithOnlyUnderscores() throws {
-        // Given
         let fileName = "___"
         
-        // When & Then
         XCTAssertThrowsError(try SwiftFileNameValidator.validate(fileName)) { error in
             XCTAssertTrue(error is SwiftFileNameValidationError)
             if case SwiftFileNameValidationError.missingSwiftExtension = error {
@@ -576,18 +474,14 @@ final class SwiftFileNameValidatorTests: XCTestCase {
     }
     
     func testFileNameWithOnlyUnderscoresAndExtension() throws {
-        // Given
         let fileName = "___.swift"
         
-        // When & Then
         XCTAssertNoThrow(try SwiftFileNameValidator.validate(fileName))
     }
     
     func testFileNameWithNumbersAndUnderscores() throws {
-        // Given
         let fileName = "Event_123_Test.swift"
         
-        // When & Then
         XCTAssertNoThrow(try SwiftFileNameValidator.validate(fileName))
     }
 }

--- a/Tests/EventPanelCLITests/SwiftFileNameValidatorTests.swift
+++ b/Tests/EventPanelCLITests/SwiftFileNameValidatorTests.swift
@@ -2,44 +2,44 @@ import XCTest
 @testable import eventpanel
 
 final class SwiftFileNameValidatorTests: XCTestCase {
-    
+
     // MARK: - Valid File Names
-    
+
     func testValidFileName() throws {
         let fileName = "Events.swift"
-        
+
         XCTAssertNoThrow(try SwiftFileNameValidator.validate(fileName))
     }
-    
+
     func testValidFileNameWithUnderscore() throws {
         let fileName = "Analytics_Events.swift"
-        
+
         XCTAssertNoThrow(try SwiftFileNameValidator.validate(fileName))
     }
-    
+
     func testValidFileNameWithNumbers() throws {
         let fileName = "Event2.swift"
-        
+
         XCTAssertNoThrow(try SwiftFileNameValidator.validate(fileName))
     }
-    
+
     func testValidFileNameStartingWithUnderscore() throws {
         let fileName = "_PrivateEvents.swift"
-        
+
         XCTAssertNoThrow(try SwiftFileNameValidator.validate(fileName))
     }
-    
+
     func testValidFileNameWithWhitespace() throws {
         let fileName = "  Events.swift  "
-        
+
         XCTAssertNoThrow(try SwiftFileNameValidator.validate(fileName))
     }
-    
+
     // MARK: - Empty File Name Tests
-    
+
     func testEmptyFileName() {
         let fileName = ""
-        
+
         XCTAssertThrowsError(try SwiftFileNameValidator.validate(fileName)) { error in
             XCTAssertTrue(error is SwiftFileNameValidationError)
             if case SwiftFileNameValidationError.emptyFileName = error {
@@ -49,10 +49,10 @@ final class SwiftFileNameValidatorTests: XCTestCase {
             }
         }
     }
-    
+
     func testWhitespaceOnlyFileName() {
         let fileName = "   "
-        
+
         XCTAssertThrowsError(try SwiftFileNameValidator.validate(fileName)) { error in
             XCTAssertTrue(error is SwiftFileNameValidationError)
             if case SwiftFileNameValidationError.emptyFileName = error {
@@ -62,10 +62,10 @@ final class SwiftFileNameValidatorTests: XCTestCase {
             }
         }
     }
-    
+
     func testNewlineOnlyFileName() {
         let fileName = "\n\t"
-        
+
         XCTAssertThrowsError(try SwiftFileNameValidator.validate(fileName)) { error in
             XCTAssertTrue(error is SwiftFileNameValidationError)
             if case SwiftFileNameValidationError.emptyFileName = error {
@@ -75,12 +75,12 @@ final class SwiftFileNameValidatorTests: XCTestCase {
             }
         }
     }
-    
+
     // MARK: - Missing Extension Tests
-    
+
     func testMissingSwiftExtension() {
         let fileName = "Events"
-        
+
         XCTAssertThrowsError(try SwiftFileNameValidator.validate(fileName)) { error in
             XCTAssertTrue(error is SwiftFileNameValidationError)
             if case SwiftFileNameValidationError.missingSwiftExtension = error {
@@ -90,10 +90,10 @@ final class SwiftFileNameValidatorTests: XCTestCase {
             }
         }
     }
-    
+
     func testWrongExtension() {
         let fileName = "Events.txt"
-        
+
         XCTAssertThrowsError(try SwiftFileNameValidator.validate(fileName)) { error in
             XCTAssertTrue(error is SwiftFileNameValidationError)
             if case SwiftFileNameValidationError.missingSwiftExtension = error {
@@ -103,10 +103,10 @@ final class SwiftFileNameValidatorTests: XCTestCase {
             }
         }
     }
-    
+
     func testCaseSensitiveExtension() {
         let fileName = "Events.SWIFT"
-        
+
         XCTAssertThrowsError(try SwiftFileNameValidator.validate(fileName)) { error in
             XCTAssertTrue(error is SwiftFileNameValidationError)
             if case SwiftFileNameValidationError.missingSwiftExtension = error {
@@ -116,12 +116,12 @@ final class SwiftFileNameValidatorTests: XCTestCase {
             }
         }
     }
-    
+
     // MARK: - Empty Base Name Tests
-    
+
     func testEmptyBaseName() {
         let fileName = ".swift"
-        
+
         XCTAssertThrowsError(try SwiftFileNameValidator.validate(fileName)) { error in
             XCTAssertTrue(error is SwiftFileNameValidationError)
             if case SwiftFileNameValidationError.emptyBaseName = error {
@@ -131,10 +131,10 @@ final class SwiftFileNameValidatorTests: XCTestCase {
             }
         }
     }
-    
+
     func testWhitespaceBaseName() {
         let fileName = "   .swift"
-        
+
         XCTAssertThrowsError(try SwiftFileNameValidator.validate(fileName)) { error in
             XCTAssertTrue(error is SwiftFileNameValidationError)
             if case SwiftFileNameValidationError.emptyBaseName = error {
@@ -144,12 +144,12 @@ final class SwiftFileNameValidatorTests: XCTestCase {
             }
         }
     }
-    
+
     // MARK: - Invalid Start Character Tests
-    
+
     func testInvalidStartCharacterNumber() {
         let fileName = "2Events.swift"
-        
+
         XCTAssertThrowsError(try SwiftFileNameValidator.validate(fileName)) { error in
             XCTAssertTrue(error is SwiftFileNameValidationError)
             if case SwiftFileNameValidationError.invalidStartCharacter = error {
@@ -159,10 +159,10 @@ final class SwiftFileNameValidatorTests: XCTestCase {
             }
         }
     }
-    
+
     func testInvalidStartCharacterSpecialChar() {
         let fileName = "@Events.swift"
-        
+
         XCTAssertThrowsError(try SwiftFileNameValidator.validate(fileName)) { error in
             XCTAssertTrue(error is SwiftFileNameValidationError)
             if case SwiftFileNameValidationError.invalidStartCharacter = error {
@@ -172,10 +172,10 @@ final class SwiftFileNameValidatorTests: XCTestCase {
             }
         }
     }
-    
+
     func testInvalidStartCharacterDollarSign() {
         let fileName = "$Events.swift"
-        
+
         XCTAssertThrowsError(try SwiftFileNameValidator.validate(fileName)) { error in
             XCTAssertTrue(error is SwiftFileNameValidationError)
             if case SwiftFileNameValidationError.invalidStartCharacter = error {
@@ -185,67 +185,66 @@ final class SwiftFileNameValidatorTests: XCTestCase {
             }
         }
     }
-    
+
     // MARK: - Invalid Characters Tests
-    
+
     func testValidFileNameWithHyphen() throws {
         let fileName = "Events-File.swift"
-        
+
         XCTAssertNoThrow(try SwiftFileNameValidator.validate(fileName))
     }
-    
+
     func testValidFileNameWithPeriod() throws {
         let fileName = "Events.File.swift"
-        
+
         XCTAssertNoThrow(try SwiftFileNameValidator.validate(fileName))
     }
-    
+
     func testValidFileNameWithMultiplePeriods() throws {
         let fileName = "Events.File.Utils.swift"
-        
+
         XCTAssertNoThrow(try SwiftFileNameValidator.validate(fileName))
     }
-    
+
     func testValidFileNameWithPlus() throws {
         let fileName = "Events+File.swift"
-        
+
         XCTAssertNoThrow(try SwiftFileNameValidator.validate(fileName))
     }
-    
+
     func testValidFileNameWithSpace() throws {
         let fileName = "Events File.swift"
-        
+
         XCTAssertNoThrow(try SwiftFileNameValidator.validate(fileName))
     }
-    
+
     func testValidFileNameWithAtSign() throws {
         let fileName = "Events@File.swift"
-        
+
         XCTAssertNoThrow(try SwiftFileNameValidator.validate(fileName))
     }
-    
+
     func testValidFileNameWithHash() throws {
         let fileName = "Events#File.swift"
-        
+
         XCTAssertNoThrow(try SwiftFileNameValidator.validate(fileName))
     }
-    
+
     func testValidFileNameWithPercent() throws {
         let fileName = "Events%File.swift"
-        
+
         XCTAssertNoThrow(try SwiftFileNameValidator.validate(fileName))
     }
-    
+
     func testValidFileNameWithExclamation() throws {
         let fileName = "Events!File.swift"
-        
+
         XCTAssertNoThrow(try SwiftFileNameValidator.validate(fileName))
     }
-    
-    
+
     func testInvalidCharactersColon() {
         let fileName = "Events:File.swift"
-        
+
         XCTAssertThrowsError(try SwiftFileNameValidator.validate(fileName)) { error in
             XCTAssertTrue(error is SwiftFileNameValidationError)
             if case SwiftFileNameValidationError.invalidCharacters = error {
@@ -255,10 +254,10 @@ final class SwiftFileNameValidatorTests: XCTestCase {
             }
         }
     }
-    
+
     func testInvalidCharactersSlash() {
         let fileName = "Events/File.swift"
-        
+
         XCTAssertThrowsError(try SwiftFileNameValidator.validate(fileName)) { error in
             XCTAssertTrue(error is SwiftFileNameValidationError)
             if case SwiftFileNameValidationError.invalidCharacters = error {
@@ -268,10 +267,10 @@ final class SwiftFileNameValidatorTests: XCTestCase {
             }
         }
     }
-    
+
     func testInvalidCharactersBackslash() {
         let fileName = "Events\\File.swift"
-        
+
         XCTAssertThrowsError(try SwiftFileNameValidator.validate(fileName)) { error in
             XCTAssertTrue(error is SwiftFileNameValidationError)
             if case SwiftFileNameValidationError.invalidCharacters = error {
@@ -281,10 +280,10 @@ final class SwiftFileNameValidatorTests: XCTestCase {
             }
         }
     }
-    
+
     func testInvalidCharactersQuestionMark() {
         let fileName = "Events?File.swift"
-        
+
         XCTAssertThrowsError(try SwiftFileNameValidator.validate(fileName)) { error in
             XCTAssertTrue(error is SwiftFileNameValidationError)
             if case SwiftFileNameValidationError.invalidCharacters = error {
@@ -294,10 +293,10 @@ final class SwiftFileNameValidatorTests: XCTestCase {
             }
         }
     }
-    
+
     func testInvalidCharactersAsterisk() {
         let fileName = "Events*File.swift"
-        
+
         XCTAssertThrowsError(try SwiftFileNameValidator.validate(fileName)) { error in
             XCTAssertTrue(error is SwiftFileNameValidationError)
             if case SwiftFileNameValidationError.invalidCharacters = error {
@@ -307,10 +306,10 @@ final class SwiftFileNameValidatorTests: XCTestCase {
             }
         }
     }
-    
+
     func testInvalidCharactersQuote() {
         let fileName = "Events\"File.swift"
-        
+
         XCTAssertThrowsError(try SwiftFileNameValidator.validate(fileName)) { error in
             XCTAssertTrue(error is SwiftFileNameValidationError)
             if case SwiftFileNameValidationError.invalidCharacters = error {
@@ -320,10 +319,10 @@ final class SwiftFileNameValidatorTests: XCTestCase {
             }
         }
     }
-    
+
     func testInvalidCharactersLessThan() {
         let fileName = "Events<File.swift"
-        
+
         XCTAssertThrowsError(try SwiftFileNameValidator.validate(fileName)) { error in
             XCTAssertTrue(error is SwiftFileNameValidationError)
             if case SwiftFileNameValidationError.invalidCharacters = error {
@@ -333,10 +332,10 @@ final class SwiftFileNameValidatorTests: XCTestCase {
             }
         }
     }
-    
+
     func testInvalidCharactersGreaterThan() {
         let fileName = "Events>File.swift"
-        
+
         XCTAssertThrowsError(try SwiftFileNameValidator.validate(fileName)) { error in
             XCTAssertTrue(error is SwiftFileNameValidationError)
             if case SwiftFileNameValidationError.invalidCharacters = error {
@@ -346,10 +345,10 @@ final class SwiftFileNameValidatorTests: XCTestCase {
             }
         }
     }
-    
+
     func testInvalidCharactersPipe() {
         let fileName = "Events|File.swift"
-        
+
         XCTAssertThrowsError(try SwiftFileNameValidator.validate(fileName)) { error in
             XCTAssertTrue(error is SwiftFileNameValidationError)
             if case SwiftFileNameValidationError.invalidCharacters = error {
@@ -359,110 +358,110 @@ final class SwiftFileNameValidatorTests: XCTestCase {
             }
         }
     }
-    
+
     // MARK: - Valid Reserved Keyword File Names (These should now be valid)
-    
+
     func testValidReservedKeywordClass() throws {
         let fileName = "class.swift"
-        
+
         XCTAssertNoThrow(try SwiftFileNameValidator.validate(fileName))
     }
-    
+
     func testValidReservedKeywordFunc() throws {
         let fileName = "func.swift"
-        
+
         XCTAssertNoThrow(try SwiftFileNameValidator.validate(fileName))
     }
-    
+
     func testValidReservedKeywordStruct() throws {
         let fileName = "struct.swift"
-        
+
         XCTAssertNoThrow(try SwiftFileNameValidator.validate(fileName))
     }
-    
+
     func testValidReservedKeywordEnum() throws {
         let fileName = "enum.swift"
-        
+
         XCTAssertNoThrow(try SwiftFileNameValidator.validate(fileName))
     }
-    
+
     func testValidReservedKeywordProtocol() throws {
         let fileName = "protocol.swift"
-        
+
         XCTAssertNoThrow(try SwiftFileNameValidator.validate(fileName))
     }
-    
+
     func testValidReservedKeywordImport() throws {
         let fileName = "import.swift"
-        
+
         XCTAssertNoThrow(try SwiftFileNameValidator.validate(fileName))
     }
-    
+
     func testValidReservedKeywordVar() throws {
         let fileName = "var.swift"
-        
+
         XCTAssertNoThrow(try SwiftFileNameValidator.validate(fileName))
     }
-    
+
     func testValidReservedKeywordLet() throws {
         let fileName = "let.swift"
-        
+
         XCTAssertNoThrow(try SwiftFileNameValidator.validate(fileName))
     }
-    
+
     func testValidReservedKeywordIf() throws {
         let fileName = "if.swift"
-        
+
         XCTAssertNoThrow(try SwiftFileNameValidator.validate(fileName))
     }
-    
+
     func testValidReservedKeywordFor() throws {
         let fileName = "for.swift"
-        
+
         XCTAssertNoThrow(try SwiftFileNameValidator.validate(fileName))
     }
-    
+
     func testValidReservedKeywordWhile() throws {
         let fileName = "while.swift"
-        
+
         XCTAssertNoThrow(try SwiftFileNameValidator.validate(fileName))
     }
-    
+
     func testValidReservedKeywordReturn() throws {
         let fileName = "return.swift"
-        
+
         XCTAssertNoThrow(try SwiftFileNameValidator.validate(fileName))
     }
-    
+
     func testValidReservedKeywordTrue() throws {
         let fileName = "true.swift"
-        
+
         XCTAssertNoThrow(try SwiftFileNameValidator.validate(fileName))
     }
-    
+
     func testValidReservedKeywordFalse() throws {
         let fileName = "false.swift"
-        
+
         XCTAssertNoThrow(try SwiftFileNameValidator.validate(fileName))
     }
-    
+
     func testValidReservedKeywordNil() throws {
         let fileName = "nil.swift"
-        
+
         XCTAssertNoThrow(try SwiftFileNameValidator.validate(fileName))
     }
-    
+
     // MARK: - Edge Cases
-    
+
     func testVeryLongValidFileName() throws {
         let fileName = String(repeating: "A", count: 100) + ".swift"
-        
+
         XCTAssertNoThrow(try SwiftFileNameValidator.validate(fileName))
     }
-    
+
     func testFileNameWithOnlyUnderscores() throws {
         let fileName = "___"
-        
+
         XCTAssertThrowsError(try SwiftFileNameValidator.validate(fileName)) { error in
             XCTAssertTrue(error is SwiftFileNameValidationError)
             if case SwiftFileNameValidationError.missingSwiftExtension = error {
@@ -472,16 +471,16 @@ final class SwiftFileNameValidatorTests: XCTestCase {
             }
         }
     }
-    
+
     func testFileNameWithOnlyUnderscoresAndExtension() throws {
         let fileName = "___.swift"
-        
+
         XCTAssertNoThrow(try SwiftFileNameValidator.validate(fileName))
     }
-    
+
     func testFileNameWithNumbersAndUnderscores() throws {
         let fileName = "Event_123_Test.swift"
-        
+
         XCTAssertNoThrow(try SwiftFileNameValidator.validate(fileName))
     }
 }

--- a/Tests/EventPanelCLITests/SwiftGenGeneratorTests.swift
+++ b/Tests/EventPanelCLITests/SwiftGenGeneratorTests.swift
@@ -6,7 +6,6 @@ final class SwiftGenGeneratorTests: XCTestCase {
     let stencilTemplate = try! SwiftGenStencilTemplate.default()
 
     func testGenerateAnalyticsEvents() throws {
-        // Given
         let config = SwiftGenPlugin.default
         let generator = SwiftGenGenerator(config: config)
         
@@ -51,7 +50,6 @@ final class SwiftGenGeneratorTests: XCTestCase {
             ]
         )
         
-        // When
         let output = try generator.generate(scheme: scheme, stencilTemplate: stencilTemplate)
         
         // Then
@@ -59,7 +57,6 @@ final class SwiftGenGeneratorTests: XCTestCase {
     }
     
     func testGenerateAnalyticsEventsWithMultipleEvents() throws {
-        // Given
         let config = SwiftGenPlugin.default
         let generator = SwiftGenGenerator(config: config)
         
@@ -113,7 +110,6 @@ final class SwiftGenGeneratorTests: XCTestCase {
             ]
         )
 
-        // When
         let output = try generator.generate(scheme: scheme, stencilTemplate: stencilTemplate)
         
         // Then
@@ -121,7 +117,6 @@ final class SwiftGenGeneratorTests: XCTestCase {
     }
     
     func testGenerateAnalyticsEventsWithComplexProperties() throws {
-        // Given
         let config = SwiftGenPlugin.default
         let generator = SwiftGenGenerator(config: config)
         
@@ -183,7 +178,6 @@ final class SwiftGenGeneratorTests: XCTestCase {
             ]
         )
         
-        // When
         let output = try generator.generate(scheme: scheme, stencilTemplate: stencilTemplate)
         
         // Then
@@ -191,7 +185,6 @@ final class SwiftGenGeneratorTests: XCTestCase {
     }
     
     func testGenerateAnalyticsEventsWithCustomTypes() throws {
-        // Given
         let config = SwiftGenPlugin.default
         let generator = SwiftGenGenerator(config: config)
         
@@ -242,7 +235,6 @@ final class SwiftGenGeneratorTests: XCTestCase {
             ]
         )
         
-        // When
         let output = try generator.generate(scheme: scheme, stencilTemplate: stencilTemplate)
         
         // Then
@@ -250,7 +242,6 @@ final class SwiftGenGeneratorTests: XCTestCase {
     }
 
     func testUncategorisedEvents() throws {
-        // Given
         let config = SwiftGenPlugin.default
         let generator = SwiftGenGenerator(config: config)
 
@@ -286,7 +277,6 @@ final class SwiftGenGeneratorTests: XCTestCase {
             categories: nil
         )
 
-        // When
         let output = try generator.generate(scheme: scheme, stencilTemplate: stencilTemplate)
 
         // Then
@@ -294,7 +284,6 @@ final class SwiftGenGeneratorTests: XCTestCase {
     }
 
     func testEventWithEmptyDescription() throws {
-        // Given
         let config = SwiftGenPlugin.default
         let generator = SwiftGenGenerator(config: config)
 
@@ -330,7 +319,6 @@ final class SwiftGenGeneratorTests: XCTestCase {
             categories: []
         )
 
-        // When
         let output = try generator.generate(scheme: scheme, stencilTemplate: stencilTemplate)
 
         // Then
@@ -338,7 +326,6 @@ final class SwiftGenGeneratorTests: XCTestCase {
     }
 
     func testEventWithEmptyProperties() throws {
-        // Given
         let config = SwiftGenPlugin.default
         let generator = SwiftGenGenerator(config: config)
 
@@ -357,7 +344,6 @@ final class SwiftGenGeneratorTests: XCTestCase {
             categories: []
         )
 
-        // When
         let output = try generator.generate(scheme: scheme, stencilTemplate: stencilTemplate)
 
         // Then
@@ -365,7 +351,6 @@ final class SwiftGenGeneratorTests: XCTestCase {
     }
 
     func testEventWithPropertyWithEmptyDescription() throws {
-        // Given
         let config = SwiftGenPlugin.default
         let generator = SwiftGenGenerator(config: config)
 
@@ -393,7 +378,6 @@ final class SwiftGenGeneratorTests: XCTestCase {
             categories: []
         )
 
-        // When
         let output = try generator.generate(scheme: scheme, stencilTemplate: stencilTemplate)
 
         // Then
@@ -401,7 +385,6 @@ final class SwiftGenGeneratorTests: XCTestCase {
     }
 
     func testCategoryDescription() throws {
-        // Given
         let config = SwiftGenPlugin.default
         let generator = SwiftGenGenerator(config: config)
 
@@ -435,7 +418,6 @@ final class SwiftGenGeneratorTests: XCTestCase {
             ]
         )
 
-        // When
         let output = try generator.generate(scheme: scheme, stencilTemplate: stencilTemplate)
 
         // Then
@@ -443,7 +425,6 @@ final class SwiftGenGeneratorTests: XCTestCase {
     }
 
     func testWithoutTypeDefinition() throws {
-        // Given
         let config = SwiftGenPlugin(
             outputFilePath: "GeneratedAnalyticsEvents.swift",
             namespace: "AnalyticsEvents",
@@ -483,7 +464,6 @@ final class SwiftGenGeneratorTests: XCTestCase {
             ]
         )
 
-        // When
         let output = try generator.generate(scheme: scheme, stencilTemplate: stencilTemplate)
 
         // Then

--- a/Tests/EventPanelCLITests/SwiftGenGeneratorTests.swift
+++ b/Tests/EventPanelCLITests/SwiftGenGeneratorTests.swift
@@ -441,4 +441,52 @@ final class SwiftGenGeneratorTests: XCTestCase {
         // Then
         assertSnapshot(of: output, as: .txt)
     }
+
+    func testWithoutTypeDefenition() throws {
+        // Given
+        let config = SwiftGenPlugin(
+            outputFilePath: "GeneratedAnalyticsEvents.swift",
+            namespace: "AnalyticsEvents",
+            eventTypeName: "AnalyticsEvent",
+            documentation: true,
+            shouldGenerateType: false
+        )
+        let generator = SwiftGenGenerator(config: config)
+
+        let scheme = SwiftGenWorkspaceScheme(
+            workspace: "test-workspace",
+            events: [
+                .init(
+                    id: "productView",
+                    name: "Product View",
+                    description: "User viewed a product",
+                    categoryIds: ["ecommerce"],
+                    properties: [
+                        .init(
+                            id: "product_id",
+                            name: "product_id",
+                            description: "Unique identifier of the product",
+                            dataType: .string,
+                            required: true,
+                            value: nil
+                        )
+                    ]
+                )
+            ],
+            customTypes: [],
+            categories: [
+                .init(
+                    id: "ecommerce",
+                    name: "E-commerce",
+                    description: "Screen represents a lot of products"
+                )
+            ]
+        )
+
+        // When
+        let output = try generator.generate(scheme: scheme, stencilTemplate: stencilTemplate)
+
+        // Then
+        assertSnapshot(of: output, as: .txt)
+    }
 }

--- a/Tests/EventPanelCLITests/SwiftGenGeneratorTests.swift
+++ b/Tests/EventPanelCLITests/SwiftGenGeneratorTests.swift
@@ -442,7 +442,7 @@ final class SwiftGenGeneratorTests: XCTestCase {
         assertSnapshot(of: output, as: .txt)
     }
 
-    func testWithoutTypeDefenition() throws {
+    func testWithoutTypeDefinition() throws {
         // Given
         let config = SwiftGenPlugin(
             outputFilePath: "GeneratedAnalyticsEvents.swift",

--- a/Tests/EventPanelCLITests/SwiftGenGeneratorTests.swift
+++ b/Tests/EventPanelCLITests/SwiftGenGeneratorTests.swift
@@ -8,7 +8,7 @@ final class SwiftGenGeneratorTests: XCTestCase {
     func testGenerateAnalyticsEvents() throws {
         let config = SwiftGenPlugin.default
         let generator = SwiftGenGenerator(config: config)
-        
+
         let scheme = SwiftGenWorkspaceScheme(
             workspace: "test-workspace",
             events: [
@@ -49,17 +49,17 @@ final class SwiftGenGeneratorTests: XCTestCase {
                 .init(id: "user", name: "User", description: nil)
             ]
         )
-        
+
         let output = try generator.generate(scheme: scheme, stencilTemplate: stencilTemplate)
-        
+
         // Then
         assertSnapshot(of: output, as: .txt)
     }
-    
+
     func testGenerateAnalyticsEventsWithMultipleEvents() throws {
         let config = SwiftGenPlugin.default
         let generator = SwiftGenGenerator(config: config)
-        
+
         let scheme = SwiftGenWorkspaceScheme(
             workspace: "test-workspace",
             events: [
@@ -111,15 +111,15 @@ final class SwiftGenGeneratorTests: XCTestCase {
         )
 
         let output = try generator.generate(scheme: scheme, stencilTemplate: stencilTemplate)
-        
+
         // Then
         assertSnapshot(of: output, as: .txt)
     }
-    
+
     func testGenerateAnalyticsEventsWithComplexProperties() throws {
         let config = SwiftGenPlugin.default
         let generator = SwiftGenGenerator(config: config)
-        
+
         let scheme = SwiftGenWorkspaceScheme(
             workspace: "test-workspace",
             events: [
@@ -177,17 +177,17 @@ final class SwiftGenGeneratorTests: XCTestCase {
                 .init(id: "ecommerce", name: "E-commerce", description: nil)
             ]
         )
-        
+
         let output = try generator.generate(scheme: scheme, stencilTemplate: stencilTemplate)
-        
+
         // Then
         assertSnapshot(of: output, as: .txt)
     }
-    
+
     func testGenerateAnalyticsEventsWithCustomTypes() throws {
         let config = SwiftGenPlugin.default
         let generator = SwiftGenGenerator(config: config)
-        
+
         let scheme = SwiftGenWorkspaceScheme(
             workspace: "test-workspace",
             events: [
@@ -234,9 +234,9 @@ final class SwiftGenGeneratorTests: XCTestCase {
                 .init(id: "payment", name: "Payment", description: nil)
             ]
         )
-        
+
         let output = try generator.generate(scheme: scheme, stencilTemplate: stencilTemplate)
-        
+
         // Then
         assertSnapshot(of: output, as: .txt)
     }

--- a/Tests/EventPanelCLITests/__Snapshots__/KotlinGenGeneratorTests/testEventWithEmptyDescription.1.txt
+++ b/Tests/EventPanelCLITests/__Snapshots__/KotlinGenGeneratorTests/testEventWithEmptyDescription.1.txt
@@ -18,5 +18,10 @@ internal object GeneratedAnalyticsEvents {
   }
 }
 
+internal data class AnalyticsEvent(
+  internal val name: String,
+  internal val parameters: Map<String, Any> = emptyMap()
+)
+
 private fun Map<String, Any?>.withoutNulls(): Map<String, Any> =
     this.filterValues { it != null }.mapValues { it.value!! }

--- a/Tests/EventPanelCLITests/__Snapshots__/KotlinGenGeneratorTests/testEventWithEmptyProperties.1.txt
+++ b/Tests/EventPanelCLITests/__Snapshots__/KotlinGenGeneratorTests/testEventWithEmptyProperties.1.txt
@@ -12,5 +12,10 @@ internal object GeneratedAnalyticsEvents {
   }
 }
 
+internal data class AnalyticsEvent(
+  internal val name: String,
+  internal val parameters: Map<String, Any> = emptyMap()
+)
+
 private fun Map<String, Any?>.withoutNulls(): Map<String, Any> =
     this.filterValues { it != null }.mapValues { it.value!! }

--- a/Tests/EventPanelCLITests/__Snapshots__/KotlinGenGeneratorTests/testEventWithPropertyWithEmptyDescription.1.txt
+++ b/Tests/EventPanelCLITests/__Snapshots__/KotlinGenGeneratorTests/testEventWithPropertyWithEmptyDescription.1.txt
@@ -16,5 +16,10 @@ internal object GeneratedAnalyticsEvents {
   }
 }
 
+internal data class AnalyticsEvent(
+  internal val name: String,
+  internal val parameters: Map<String, Any> = emptyMap()
+)
+
 private fun Map<String, Any?>.withoutNulls(): Map<String, Any> =
     this.filterValues { it != null }.mapValues { it.value!! }

--- a/Tests/EventPanelCLITests/__Snapshots__/KotlinGenGeneratorTests/testGenerateAnalyticsEvents.1.txt
+++ b/Tests/EventPanelCLITests/__Snapshots__/KotlinGenGeneratorTests/testGenerateAnalyticsEvents.1.txt
@@ -33,5 +33,10 @@ internal enum class Method(val value: String) {
   Apple("apple")
 }
 
+internal data class AnalyticsEvent(
+  internal val name: String,
+  internal val parameters: Map<String, Any> = emptyMap()
+)
+
 private fun Map<String, Any?>.withoutNulls(): Map<String, Any> =
     this.filterValues { it != null }.mapValues { it.value!! }

--- a/Tests/EventPanelCLITests/__Snapshots__/KotlinGenGeneratorTests/testGenerateAnalyticsEventsWithComplexProperties.1.txt
+++ b/Tests/EventPanelCLITests/__Snapshots__/KotlinGenGeneratorTests/testGenerateAnalyticsEventsWithComplexProperties.1.txt
@@ -35,5 +35,10 @@ internal object GeneratedAnalyticsEvents {
 
 }
 
+internal data class AnalyticsEvent(
+  internal val name: String,
+  internal val parameters: Map<String, Any> = emptyMap()
+)
+
 private fun Map<String, Any?>.withoutNulls(): Map<String, Any> =
     this.filterValues { it != null }.mapValues { it.value!! }

--- a/Tests/EventPanelCLITests/__Snapshots__/KotlinGenGeneratorTests/testGenerateAnalyticsEventsWithCustomTypes.1.txt
+++ b/Tests/EventPanelCLITests/__Snapshots__/KotlinGenGeneratorTests/testGenerateAnalyticsEventsWithCustomTypes.1.txt
@@ -40,5 +40,10 @@ internal enum class PaymentStatus(val value: String) {
   Refunded("refunded")
 }
 
+internal data class AnalyticsEvent(
+  internal val name: String,
+  internal val parameters: Map<String, Any> = emptyMap()
+)
+
 private fun Map<String, Any?>.withoutNulls(): Map<String, Any> =
     this.filterValues { it != null }.mapValues { it.value!! }

--- a/Tests/EventPanelCLITests/__Snapshots__/KotlinGenGeneratorTests/testGenerateAnalyticsEventsWithMultipleEvents.1.txt
+++ b/Tests/EventPanelCLITests/__Snapshots__/KotlinGenGeneratorTests/testGenerateAnalyticsEventsWithMultipleEvents.1.txt
@@ -41,5 +41,10 @@ internal object GeneratedAnalyticsEvents {
 
 }
 
+internal data class AnalyticsEvent(
+  internal val name: String,
+  internal val parameters: Map<String, Any> = emptyMap()
+)
+
 private fun Map<String, Any?>.withoutNulls(): Map<String, Any> =
     this.filterValues { it != null }.mapValues { it.value!! }

--- a/Tests/EventPanelCLITests/__Snapshots__/KotlinGenGeneratorTests/testUncategorisedEvents.1.txt
+++ b/Tests/EventPanelCLITests/__Snapshots__/KotlinGenGeneratorTests/testUncategorisedEvents.1.txt
@@ -23,5 +23,10 @@ internal object GeneratedAnalyticsEvents {
   }
 }
 
+internal data class AnalyticsEvent(
+  internal val name: String,
+  internal val parameters: Map<String, Any> = emptyMap()
+)
+
 private fun Map<String, Any?>.withoutNulls(): Map<String, Any> =
     this.filterValues { it != null }.mapValues { it.value!! }

--- a/Tests/EventPanelCLITests/__Snapshots__/KotlinGenGeneratorTests/testWithoutTypeDefinition.1.txt
+++ b/Tests/EventPanelCLITests/__Snapshots__/KotlinGenGeneratorTests/testWithoutTypeDefinition.1.txt
@@ -26,10 +26,5 @@ internal object GeneratedAnalyticsEvents {
 
 }
 
-internal data class AnalyticsEvent(
-  internal val name: String,
-  internal val parameters: Map<String, Any> = emptyMap()
-)
-
 private fun Map<String, Any?>.withoutNulls(): Map<String, Any> =
     this.filterValues { it != null }.mapValues { it.value!! }

--- a/Tests/EventPanelCLITests/__Snapshots__/SwiftGenGeneratorTests/testEventWithEmptyDescription.1.txt
+++ b/Tests/EventPanelCLITests/__Snapshots__/SwiftGenGeneratorTests/testEventWithEmptyDescription.1.txt
@@ -22,11 +22,21 @@ internal enum AnalyticsEvents {
 }
 
 private extension Dictionary where Value == Any? {
-    /// Returns dictionary with filtered out `nil` and `NSNull` values
-    func byExcludingNilValues() -> [Key: Any] {
-        return compactMapValues { value -> Any? in
-            value is NSNull ? nil : value
-        }
+  /// Returns dictionary with filtered out `nil` and `NSNull` values
+  func byExcludingNilValues() -> [Key: Any] {
+    return compactMapValues { value -> Any? in
+      value is NSNull ? nil : value
     }
-} 
+  }
+}
+
+internal struct AnalyticsEvent {
+  internal let name: String
+  internal let parameters: [String: Any]
+
+  internal init(name: String, parameters: [String: Any] = [:]) {
+    self.name = name
+    self.parameters = parameters
+  }
+}
 // swiftlint:enable all

--- a/Tests/EventPanelCLITests/__Snapshots__/SwiftGenGeneratorTests/testEventWithEmptyProperties.1.txt
+++ b/Tests/EventPanelCLITests/__Snapshots__/SwiftGenGeneratorTests/testEventWithEmptyProperties.1.txt
@@ -13,11 +13,21 @@ internal enum AnalyticsEvents {
 }
 
 private extension Dictionary where Value == Any? {
-    /// Returns dictionary with filtered out `nil` and `NSNull` values
-    func byExcludingNilValues() -> [Key: Any] {
-        return compactMapValues { value -> Any? in
-            value is NSNull ? nil : value
-        }
+  /// Returns dictionary with filtered out `nil` and `NSNull` values
+  func byExcludingNilValues() -> [Key: Any] {
+    return compactMapValues { value -> Any? in
+      value is NSNull ? nil : value
     }
-} 
+  }
+}
+
+internal struct AnalyticsEvent {
+  internal let name: String
+  internal let parameters: [String: Any]
+
+  internal init(name: String, parameters: [String: Any] = [:]) {
+    self.name = name
+    self.parameters = parameters
+  }
+}
 // swiftlint:enable all

--- a/Tests/EventPanelCLITests/__Snapshots__/SwiftGenGeneratorTests/testEventWithPropertyWithEmptyDescription.1.txt
+++ b/Tests/EventPanelCLITests/__Snapshots__/SwiftGenGeneratorTests/testEventWithPropertyWithEmptyDescription.1.txt
@@ -17,11 +17,21 @@ internal enum AnalyticsEvents {
 }
 
 private extension Dictionary where Value == Any? {
-    /// Returns dictionary with filtered out `nil` and `NSNull` values
-    func byExcludingNilValues() -> [Key: Any] {
-        return compactMapValues { value -> Any? in
-            value is NSNull ? nil : value
-        }
+  /// Returns dictionary with filtered out `nil` and `NSNull` values
+  func byExcludingNilValues() -> [Key: Any] {
+    return compactMapValues { value -> Any? in
+      value is NSNull ? nil : value
     }
-} 
+  }
+}
+
+internal struct AnalyticsEvent {
+  internal let name: String
+  internal let parameters: [String: Any]
+
+  internal init(name: String, parameters: [String: Any] = [:]) {
+    self.name = name
+    self.parameters = parameters
+  }
+}
 // swiftlint:enable all

--- a/Tests/EventPanelCLITests/__Snapshots__/SwiftGenGeneratorTests/testGenerateAnalyticsEvents.1.txt
+++ b/Tests/EventPanelCLITests/__Snapshots__/SwiftGenGeneratorTests/testGenerateAnalyticsEvents.1.txt
@@ -34,11 +34,21 @@ extension AnalyticsEvents {
 }
 
 private extension Dictionary where Value == Any? {
-    /// Returns dictionary with filtered out `nil` and `NSNull` values
-    func byExcludingNilValues() -> [Key: Any] {
-        return compactMapValues { value -> Any? in
-            value is NSNull ? nil : value
-        }
+  /// Returns dictionary with filtered out `nil` and `NSNull` values
+  func byExcludingNilValues() -> [Key: Any] {
+    return compactMapValues { value -> Any? in
+      value is NSNull ? nil : value
     }
-} 
+  }
+}
+
+internal struct AnalyticsEvent {
+  internal let name: String
+  internal let parameters: [String: Any]
+
+  internal init(name: String, parameters: [String: Any] = [:]) {
+    self.name = name
+    self.parameters = parameters
+  }
+}
 // swiftlint:enable all

--- a/Tests/EventPanelCLITests/__Snapshots__/SwiftGenGeneratorTests/testGenerateAnalyticsEventsWithComplexProperties.1.txt
+++ b/Tests/EventPanelCLITests/__Snapshots__/SwiftGenGeneratorTests/testGenerateAnalyticsEventsWithComplexProperties.1.txt
@@ -35,11 +35,21 @@ internal enum AnalyticsEvents {
 }
 
 private extension Dictionary where Value == Any? {
-    /// Returns dictionary with filtered out `nil` and `NSNull` values
-    func byExcludingNilValues() -> [Key: Any] {
-        return compactMapValues { value -> Any? in
-            value is NSNull ? nil : value
-        }
+  /// Returns dictionary with filtered out `nil` and `NSNull` values
+  func byExcludingNilValues() -> [Key: Any] {
+    return compactMapValues { value -> Any? in
+      value is NSNull ? nil : value
     }
-} 
+  }
+}
+
+internal struct AnalyticsEvent {
+  internal let name: String
+  internal let parameters: [String: Any]
+
+  internal init(name: String, parameters: [String: Any] = [:]) {
+    self.name = name
+    self.parameters = parameters
+  }
+}
 // swiftlint:enable all

--- a/Tests/EventPanelCLITests/__Snapshots__/SwiftGenGeneratorTests/testGenerateAnalyticsEventsWithCustomTypes.1.txt
+++ b/Tests/EventPanelCLITests/__Snapshots__/SwiftGenGeneratorTests/testGenerateAnalyticsEventsWithCustomTypes.1.txt
@@ -41,11 +41,21 @@ extension AnalyticsEvents {
 }
 
 private extension Dictionary where Value == Any? {
-    /// Returns dictionary with filtered out `nil` and `NSNull` values
-    func byExcludingNilValues() -> [Key: Any] {
-        return compactMapValues { value -> Any? in
-            value is NSNull ? nil : value
-        }
+  /// Returns dictionary with filtered out `nil` and `NSNull` values
+  func byExcludingNilValues() -> [Key: Any] {
+    return compactMapValues { value -> Any? in
+      value is NSNull ? nil : value
     }
-} 
+  }
+}
+
+internal struct AnalyticsEvent {
+  internal let name: String
+  internal let parameters: [String: Any]
+
+  internal init(name: String, parameters: [String: Any] = [:]) {
+    self.name = name
+    self.parameters = parameters
+  }
+}
 // swiftlint:enable all

--- a/Tests/EventPanelCLITests/__Snapshots__/SwiftGenGeneratorTests/testGenerateAnalyticsEventsWithMultipleEvents.1.txt
+++ b/Tests/EventPanelCLITests/__Snapshots__/SwiftGenGeneratorTests/testGenerateAnalyticsEventsWithMultipleEvents.1.txt
@@ -40,11 +40,21 @@ internal enum AnalyticsEvents {
 }
 
 private extension Dictionary where Value == Any? {
-    /// Returns dictionary with filtered out `nil` and `NSNull` values
-    func byExcludingNilValues() -> [Key: Any] {
-        return compactMapValues { value -> Any? in
-            value is NSNull ? nil : value
-        }
+  /// Returns dictionary with filtered out `nil` and `NSNull` values
+  func byExcludingNilValues() -> [Key: Any] {
+    return compactMapValues { value -> Any? in
+      value is NSNull ? nil : value
     }
-} 
+  }
+}
+
+internal struct AnalyticsEvent {
+  internal let name: String
+  internal let parameters: [String: Any]
+
+  internal init(name: String, parameters: [String: Any] = [:]) {
+    self.name = name
+    self.parameters = parameters
+  }
+}
 // swiftlint:enable all

--- a/Tests/EventPanelCLITests/__Snapshots__/SwiftGenGeneratorTests/testUncategorisedEvents.1.txt
+++ b/Tests/EventPanelCLITests/__Snapshots__/SwiftGenGeneratorTests/testUncategorisedEvents.1.txt
@@ -23,11 +23,21 @@ internal enum AnalyticsEvents {
 }
 
 private extension Dictionary where Value == Any? {
-    /// Returns dictionary with filtered out `nil` and `NSNull` values
-    func byExcludingNilValues() -> [Key: Any] {
-        return compactMapValues { value -> Any? in
-            value is NSNull ? nil : value
-        }
+  /// Returns dictionary with filtered out `nil` and `NSNull` values
+  func byExcludingNilValues() -> [Key: Any] {
+    return compactMapValues { value -> Any? in
+      value is NSNull ? nil : value
     }
-} 
+  }
+}
+
+internal struct AnalyticsEvent {
+  internal let name: String
+  internal let parameters: [String: Any]
+
+  internal init(name: String, parameters: [String: Any] = [:]) {
+    self.name = name
+    self.parameters = parameters
+  }
+}
 // swiftlint:enable all

--- a/Tests/EventPanelCLITests/__Snapshots__/SwiftGenGeneratorTests/testWithoutTypeDefenition.1.txt
+++ b/Tests/EventPanelCLITests/__Snapshots__/SwiftGenGeneratorTests/testWithoutTypeDefenition.1.txt
@@ -32,13 +32,4 @@ private extension Dictionary where Value == Any? {
   }
 }
 
-internal struct AnalyticsEvent {
-  internal let name: String
-  internal let parameters: [String: Any]
-
-  internal init(name: String, parameters: [String: Any] = [:]) {
-    self.name = name
-    self.parameters = parameters
-  }
-}
 // swiftlint:enable all

--- a/Tests/EventPanelCLITests/__Snapshots__/SwiftGenGeneratorTests/testWithoutTypeDefinition.1.txt
+++ b/Tests/EventPanelCLITests/__Snapshots__/SwiftGenGeneratorTests/testWithoutTypeDefinition.1.txt
@@ -31,5 +31,4 @@ private extension Dictionary where Value == Any? {
     }
   }
 }
-
 // swiftlint:enable all


### PR DESCRIPTION
## Description

This pull request introduces an improvement to the `add` command by changing the event version from a required argument to an optional flag, enhancing usability. It also includes minor code cleanups and a small fix to a log message.

**Command-line interface improvements:**

* Changed the `version` parameter in the `add` command from a required argument to an optional flag (`--version` or `-v`), making it easier to add events without specifying a version unless needed.

**Minor fixes and cleanups:**

* Fixed a typo in a log message by removing an unnecessary semicolon in `UpdateCommand.swift`.
* Removed extra blank lines for code cleanliness in `Generate.swift` and `InitCommand.swift`. [[1]](diffhunk://#diff-fbd00becae26765b338b11ed9dca4650082a7c67b69f1b274ede83174dade566L26) [[2]](diffhunk://#diff-4093f8c343b8b01c32aa57adf9fb4c320fa08d869d9866f744a9e05acd4920b2L57)
